### PR TITLE
fix: restore emoji status format in features table

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,19 +129,19 @@ for the complete API documentation.
 
 | Status | Feature | Description |
 | ------ | ------- | ----------- |
-| Implemented | [Providers](#providers) | Integrate with a commercial, open source, or in-house feature management tool. |
-| Implemented | [Targeting](#targeting) | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
-| Implemented | [Hooks](#hooks) | Add functionality to various stages of the flag evaluation life-cycle. |
-| Implemented | [Tracking](#tracking) | Associate user actions with feature flag evaluations for experimentation. |
-| Implemented | [Logging](#logging) | Integrate with popular logging packages. |
-| Implemented | [Domains](#domains) | Logically bind clients with providers. |
-| Experimental | [Multi-Provider](#multi-provider-experimental) | Compose multiple providers behind one SDK-level provider with a selection strategy. |
-| Implemented | [Eventing](#eventing) | React to state changes in the provider or flag management system. |
-| Implemented | [Shutdown](#shutdown) | Gracefully clean up a provider during application shutdown. |
-| Implemented | [Transaction Context Propagation](#transaction-context-propagation) | Set a specific [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context) for a transaction such as an HTTP request or thread. |
-| Implemented | [Extending](#extending) | Extend OpenFeature with custom providers and hooks. |
+| ✅ | [Providers](#providers) | Integrate with a commercial, open source, or in-house feature management tool. |
+| ✅ | [Targeting](#targeting) | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
+| ✅ | [Hooks](#hooks) | Add functionality to various stages of the flag evaluation life-cycle. |
+| ✅ | [Tracking](#tracking) | Associate user actions with feature flag evaluations for experimentation. |
+| ✅ | [Logging](#logging) | Integrate with popular logging packages. |
+| ✅ | [Domains](#domains) | Logically bind clients with providers. |
+| ⚠️ | [Multi-Provider](#multi-provider-experimental) | Compose multiple providers behind one SDK-level provider with a selection strategy. |
+| ✅ | [Eventing](#eventing) | React to state changes in the provider or flag management system. |
+| ✅ | [Shutdown](#shutdown) | Gracefully clean up a provider during application shutdown. |
+| ✅ | [Transaction Context Propagation](#transaction-context-propagation) | Set a specific [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context) for a transaction such as an HTTP request or thread. |
+| ✅ | [Extending](#extending) | Extend OpenFeature with custom providers and hooks. |
 
-<sub>Status values used here: Implemented | Experimental | Not implemented</sub>
+<sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
 
 ### Providers
 


### PR DESCRIPTION
## Summary

- Restores the emoji-based status format (`✅`, `⚠️`, `❌`) in the README features table
- The text-based format (`Implemented`, `Experimental`) introduced in #107 broke the `sdk-compatibility-generator` in [openfeature.dev](https://github.com/open-feature/openfeature.dev), which uses a regex that specifically matches those emoji to extract feature status
- This caused all Dart SDK features to show as `❓` in the [SDK compatibility matrix](https://openfeature.dev/docs/reference/sdks/sdk-compatibility), visible in open-feature/openfeature.dev#1370
- Also restores the legend text to match: `Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌`