### PR TITLE
feat(server): coordinate provider lifecycle

### DIFF
--- a/doc/provider-lifecycle-v0.9.md
+++ b/doc/provider-lifecycle-v0.9.md
@@ -1,0 +1,89 @@
+# OpenFeature v0.9 provider lifecycle migration
+
+Status: implementation preview
+
+Tracks: [#121](https://github.com/open-feature/dart-server-sdk/issues/121)
+
+OpenFeature v0.9 makes the provider the source of lifecycle events. The SDK
+updates provider status from those events before it invokes API or client event
+handlers.
+
+## Event-capable providers
+
+A provider opts into the v0.9 lifecycle contract by implementing
+`ProviderEventSource` in addition to `FeatureProvider`:
+
+```dart
+final events = StreamController<ProviderLifecycleEvent>.broadcast();
+
+@override
+Stream<ProviderLifecycleEvent> get providerEvents => events.stream;
+
+@override
+Future<void> initialize([Map<String, dynamic>? config]) async {
+  try {
+    await initializeVendorSdk();
+    events.add(
+      ProviderLifecycleEvent(
+        ProviderLifecycleEventType.PROVIDER_READY,
+        'Provider is ready.',
+      ),
+    );
+  } catch (error) {
+    events.add(
+      ProviderLifecycleEvent(
+        ProviderLifecycleEventType.PROVIDER_ERROR,
+        'Provider initialization failed.',
+        data: error,
+        errorCode: ErrorCode.PROVIDER_FATAL,
+      ),
+    );
+    rethrow;
+  }
+}
+```
+
+The ready event must be emitted before `initialize` returns normally. The error
+event must be emitted before `initialize` terminates abnormally. The SDK does
+not synthesize a missing event for a provider that implements
+`ProviderEventSource`; `setProviderAndWait` fails with a contract error instead.
+
+Providers that do not implement `ProviderEventSource` continue to work through
+the legacy lifecycle adapter. That path derives ready/error events from
+`initialize` and `state` and is retained only for migration compatibility.
+
+## Provider identity and domains
+
+Provider metadata names are descriptive and are not instance identifiers.
+Register same-name instances with explicit SDK identifiers:
+
+```dart
+await openFeature.registerProviderAndWait(
+  blueProvider,
+  providerId: 'checkout-blue',
+);
+await openFeature.registerProviderAndWait(
+  greenProvider,
+  providerId: 'checkout-green',
+);
+
+await openFeature.bindClientToProviderAndWait(
+  'checkout-blue-domain',
+  'checkout-blue',
+);
+```
+
+Existing clients resolve their provider binding dynamically. Replacing the
+default or domain provider therefore updates clients that were created before
+the replacement.
+
+A provider that implements the `DomainScopedProvider` marker can be bound to
+only one domain. The SDK rejects a second distinct domain binding for the same
+instance.
+
+## Shutdown behavior
+
+The SDK tracks default and domain bindings by provider instance. Replacing one
+binding does not shut down a provider that is still used by another binding.
+The provider is shut down once after its final binding is removed, and the SDK
+then records its status as `NOT_READY` as required by OpenFeature v0.9.

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -50,7 +50,9 @@ class FeatureClient {
   final HookManager _hookManager;
   final EvaluationContext _defaultContext;
   final EvaluationContext _apiContext;
-  final FeatureProvider _provider;
+  final FeatureProvider _fallbackProvider;
+  final FeatureProvider Function()? _providerResolver;
+  final ProviderState Function(FeatureProvider)? _providerStatusResolver;
   final TransactionContextManager _transactionManager;
   final ClientMetrics _metrics = ClientMetrics();
   final StreamController<OpenFeatureEvent> _eventController =
@@ -63,15 +65,20 @@ class FeatureClient {
     required EvaluationContext defaultContext,
     EvaluationContext? apiContext,
     FeatureProvider? provider,
+    FeatureProvider Function()? providerResolver,
+    ProviderState Function(FeatureProvider)? providerStatusResolver,
     TransactionContextManager? transactionManager,
     Stream<OpenFeatureEvent>? eventStream,
   }) : _hookManager = hookManager,
        _defaultContext = defaultContext,
        _apiContext = apiContext ?? const EvaluationContext(attributes: {}),
-       _provider = provider ?? InMemoryProvider({}),
+       _fallbackProvider = provider ?? InMemoryProvider({}),
+       _providerResolver = providerResolver,
+       _providerStatusResolver = providerStatusResolver,
        _transactionManager = transactionManager ?? TransactionContextManager() {
-    if (_provider.state == ProviderState.NOT_READY) {
-      _provider.initialize();
+    if (_providerResolver == null &&
+        providerStatus == ProviderState.NOT_READY) {
+      this.provider.initialize();
     }
 
     if (eventStream != null) {
@@ -80,8 +87,17 @@ class FeatureClient {
   }
 
   void _forwardEvent(OpenFeatureEvent event) {
+    final currentProvider = provider;
+    if (event.provider != null) {
+      if (identical(event.provider, currentProvider)) {
+        _eventController.add(event);
+      }
+      return;
+    }
+
     final eventProvider = event.providerMetadata?.name;
-    if (eventProvider == null || eventProvider == _provider.metadata.name) {
+    if (eventProvider == null ||
+        eventProvider == currentProvider.metadata.name) {
       _eventController.add(event);
     }
   }
@@ -126,7 +142,9 @@ class FeatureClient {
     return FlagValueType.OBJECT;
   }
 
-  EvaluationDetails _createEvaluationDetails<T>(FlagEvaluationResult<T> result) {
+  EvaluationDetails _createEvaluationDetails<T>(
+    FlagEvaluationResult<T> result,
+  ) {
     return EvaluationDetails(
       flagKey: result.flagKey,
       value: result.value,
@@ -153,6 +171,7 @@ class FeatureClient {
     String flagKey,
     T defaultValue,
     Exception error,
+    FeatureProvider evaluationProvider,
   ) {
     final errorCode = error is ProviderException
         ? error.code
@@ -169,7 +188,7 @@ class FeatureClient {
       errorMessage: errorMessage,
       details: error is ProviderException ? error.details : null,
       evaluatedAt: DateTime.now(),
-      evaluatorId: _provider.metadata.name,
+      evaluatorId: evaluationProvider.metadata.name,
     );
   }
 
@@ -182,6 +201,7 @@ class FeatureClient {
     String flagKey,
     T defaultValue,
     Future<FlagEvaluationResult<T>> Function(Map<String, dynamic>?) evaluator, {
+    required FeatureProvider evaluationProvider,
     Map<String, dynamic>? context,
   }) async {
     final startTime = DateTime.now();
@@ -199,7 +219,7 @@ class FeatureClient {
         flagKey,
         effectiveContext,
         clientMetadata: metadata,
-        providerMetadata: _provider.metadata,
+        providerMetadata: evaluationProvider.metadata,
         defaultValue: defaultValue,
         flagValueType: flagValueType,
         hookData: hookData,
@@ -216,7 +236,7 @@ class FeatureClient {
           result: finalResult.value,
           evaluationDetails: evaluationDetails,
           clientMetadata: metadata,
-          providerMetadata: _provider.metadata,
+          providerMetadata: evaluationProvider.metadata,
           defaultValue: defaultValue,
           flagValueType: flagValueType,
           hookData: hookData,
@@ -236,7 +256,7 @@ class FeatureClient {
           error: evaluationError,
           evaluationDetails: evaluationDetails,
           clientMetadata: metadata,
-          providerMetadata: _provider.metadata,
+          providerMetadata: evaluationProvider.metadata,
           defaultValue: defaultValue,
           flagValueType: flagValueType,
           hookData: hookData,
@@ -246,7 +266,12 @@ class FeatureClient {
       evaluationError = _asException(e);
       _logger.warning('Error evaluating flag $flagKey: $e');
       if (finalResult == null || finalResult.errorCode == null) {
-        finalResult = _exceptionResult(flagKey, defaultValue, evaluationError);
+        finalResult = _exceptionResult(
+          flagKey,
+          defaultValue,
+          evaluationError,
+          evaluationProvider,
+        );
       }
       evaluationDetails ??= _createEvaluationDetails(finalResult);
       _recordEvaluationError(finalResult.errorCode, evaluationError);
@@ -259,7 +284,7 @@ class FeatureClient {
         error: evaluationError,
         evaluationDetails: evaluationDetails,
         clientMetadata: metadata,
-        providerMetadata: _provider.metadata,
+        providerMetadata: evaluationProvider.metadata,
         defaultValue: defaultValue,
         flagValueType: flagValueType,
         hookData: hookData,
@@ -277,7 +302,7 @@ class FeatureClient {
         error: evaluationError,
         evaluationDetails: evaluationDetails,
         clientMetadata: metadata,
-        providerMetadata: _provider.metadata,
+        providerMetadata: evaluationProvider.metadata,
         defaultValue: defaultValue,
         flagValueType: flagValueType,
         hookData: hookData,
@@ -292,12 +317,14 @@ class FeatureClient {
     String flagKey,
     T defaultValue,
     Future<FlagEvaluationResult<T>> Function(Map<String, dynamic>?) evaluator, {
+    required FeatureProvider evaluationProvider,
     Map<String, dynamic>? context,
   }) async {
     final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
       evaluator,
+      evaluationProvider: evaluationProvider,
       context: context,
     );
     return result.value;
@@ -308,59 +335,90 @@ class FeatureClient {
     String flagKey, {
     EvaluationContext? context,
     bool defaultValue = false,
-  }) => _evaluateFlag(
-    flagKey,
-    defaultValue,
-    (ctx) => _provider.getBooleanFlag(flagKey, defaultValue, context: ctx),
-    context: context?.attributes,
-  );
+  }) {
+    final evaluationProvider = provider;
+    return _evaluateFlag(
+      flagKey,
+      defaultValue,
+      (ctx) => evaluationProvider.getBooleanFlag(
+        flagKey,
+        defaultValue,
+        context: ctx,
+      ),
+      evaluationProvider: evaluationProvider,
+      context: context?.attributes,
+    );
+  }
 
   /// Evaluate string flag
   Future<String> getStringFlag(
     String flagKey, {
     EvaluationContext? context,
     String defaultValue = '',
-  }) => _evaluateFlag(
-    flagKey,
-    defaultValue,
-    (ctx) => _provider.getStringFlag(flagKey, defaultValue, context: ctx),
-    context: context?.attributes,
-  );
+  }) {
+    final evaluationProvider = provider;
+    return _evaluateFlag(
+      flagKey,
+      defaultValue,
+      (ctx) =>
+          evaluationProvider.getStringFlag(flagKey, defaultValue, context: ctx),
+      evaluationProvider: evaluationProvider,
+      context: context?.attributes,
+    );
+  }
 
   /// Evaluate integer flag
   Future<int> getIntegerFlag(
     String flagKey, {
     EvaluationContext? context,
     int defaultValue = 0,
-  }) => _evaluateFlag(
-    flagKey,
-    defaultValue,
-    (ctx) => _provider.getIntegerFlag(flagKey, defaultValue, context: ctx),
-    context: context?.attributes,
-  );
+  }) {
+    final evaluationProvider = provider;
+    return _evaluateFlag(
+      flagKey,
+      defaultValue,
+      (ctx) => evaluationProvider.getIntegerFlag(
+        flagKey,
+        defaultValue,
+        context: ctx,
+      ),
+      evaluationProvider: evaluationProvider,
+      context: context?.attributes,
+    );
+  }
 
   /// Evaluate double flag
   Future<double> getDoubleFlag(
     String flagKey, {
     EvaluationContext? context,
     double defaultValue = 0.0,
-  }) => _evaluateFlag(
-    flagKey,
-    defaultValue,
-    (ctx) => _provider.getDoubleFlag(flagKey, defaultValue, context: ctx),
-    context: context?.attributes,
-  );
+  }) {
+    final evaluationProvider = provider;
+    return _evaluateFlag(
+      flagKey,
+      defaultValue,
+      (ctx) =>
+          evaluationProvider.getDoubleFlag(flagKey, defaultValue, context: ctx),
+      evaluationProvider: evaluationProvider,
+      context: context?.attributes,
+    );
+  }
 
   Future<Map<String, dynamic>> getObjectFlag(
     String flagKey, {
     EvaluationContext? context,
     Map<String, dynamic> defaultValue = const {},
-  }) => _evaluateFlag(
-    flagKey,
-    defaultValue,
-    (ctx) => _provider.getObjectFlag(flagKey, defaultValue, context: ctx),
-    context: context?.attributes,
-  );
+  }) {
+    final evaluationProvider = provider;
+    return _evaluateFlag(
+      flagKey,
+      defaultValue,
+      (ctx) =>
+          evaluationProvider.getObjectFlag(flagKey, defaultValue, context: ctx),
+      evaluationProvider: evaluationProvider,
+      context: context?.attributes,
+    );
+  }
 
   /// Tracking API (spec Section 6) - record a tracking event
   Future<void> track(
@@ -370,9 +428,10 @@ class FeatureClient {
   }) async {
     _metrics.trackingEvents++;
     final effectiveContext = _buildEffectiveContext(context?.attributes);
+    final trackingProvider = provider;
 
     try {
-      await _provider.track(
+      await trackingProvider.track(
         trackingEventName,
         evaluationContext: effectiveContext,
         trackingDetails: trackingDetails,
@@ -385,7 +444,12 @@ class FeatureClient {
   ClientMetrics getMetrics() => _metrics;
 
   /// Access to provider for management operations
-  FeatureProvider get provider => _provider;
+  FeatureProvider get provider =>
+      _providerResolver?.call() ?? _fallbackProvider;
+
+  /// Current status of the provider bound to this client.
+  ProviderState get providerStatus =>
+      _providerStatusResolver?.call(provider) ?? provider.state;
 
   Future<void> dispose() async {
     await _eventSubscription?.cancel();
@@ -401,10 +465,16 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     bool defaultValue = false,
   }) async {
+    final evaluationProvider = provider;
     final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      (ctx) => _provider.getBooleanFlag(flagKey, defaultValue, context: ctx),
+      (ctx) => evaluationProvider.getBooleanFlag(
+        flagKey,
+        defaultValue,
+        context: ctx,
+      ),
+      evaluationProvider: evaluationProvider,
       context: context?.attributes,
     );
 
@@ -417,10 +487,13 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     String defaultValue = '',
   }) async {
+    final evaluationProvider = provider;
     final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      (ctx) => _provider.getStringFlag(flagKey, defaultValue, context: ctx),
+      (ctx) =>
+          evaluationProvider.getStringFlag(flagKey, defaultValue, context: ctx),
+      evaluationProvider: evaluationProvider,
       context: context?.attributes,
     );
 
@@ -433,10 +506,16 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     int defaultValue = 0,
   }) async {
+    final evaluationProvider = provider;
     final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      (ctx) => _provider.getIntegerFlag(flagKey, defaultValue, context: ctx),
+      (ctx) => evaluationProvider.getIntegerFlag(
+        flagKey,
+        defaultValue,
+        context: ctx,
+      ),
+      evaluationProvider: evaluationProvider,
       context: context?.attributes,
     );
 
@@ -449,10 +528,13 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     double defaultValue = 0.0,
   }) async {
+    final evaluationProvider = provider;
     final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      (ctx) => _provider.getDoubleFlag(flagKey, defaultValue, context: ctx),
+      (ctx) =>
+          evaluationProvider.getDoubleFlag(flagKey, defaultValue, context: ctx),
+      evaluationProvider: evaluationProvider,
       context: context?.attributes,
     );
 
@@ -465,10 +547,13 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     Map<String, dynamic> defaultValue = const {},
   }) async {
+    final evaluationProvider = provider;
     final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      (ctx) => _provider.getObjectFlag(flagKey, defaultValue, context: ctx),
+      (ctx) =>
+          evaluationProvider.getObjectFlag(flagKey, defaultValue, context: ctx),
+      evaluationProvider: evaluationProvider,
       context: context?.attributes,
     );
 

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -7,6 +7,8 @@ import 'evaluation_context.dart';
 import 'feature_provider.dart';
 import 'hooks.dart';
 import 'open_feature_event.dart';
+import 'provider_lifecycle.dart';
+import 'src/provider_lifecycle_manager.dart';
 
 class OpenFeatureEvaluationContext {
   final Map<String, dynamic> attributes;
@@ -140,7 +142,10 @@ class OpenFeatureAPI {
 
   late FeatureProvider _provider;
   final Map<String, FeatureProvider> _providerRegistry = {};
+  final Map<String, FeatureProvider> _domainProviderBindings = {};
+  final Map<String, String> _domainProviderIds = {};
   final DomainManager _domainManager = DomainManager();
+  late final ProviderLifecycleManager _lifecycleManager;
   final List<OpenFeatureHook> _hooks = [];
   OpenFeatureEvaluationContext? _globalContext;
   StreamSubscription<Domain>? _domainSubscription;
@@ -155,6 +160,7 @@ class OpenFeatureAPI {
       _domainUpdatesController =
           StreamController<Map<String, String>>.broadcast() {
     _configureLogging();
+    _lifecycleManager = ProviderLifecycleManager(_handleProviderLifecycleEvent);
     _domainSubscription = _domainManager.domainUpdates.listen((domain) {
       _domainUpdatesController.add({
         'clientId': domain.clientId,
@@ -199,118 +205,144 @@ class OpenFeatureAPI {
   void _initializeDefaultProvider() {
     _provider = _ImmediateReadyProvider();
     _providerRegistry[_provider.metadata.name] = _provider;
+    _lifecycleManager.bindDefault(_provider);
     _logger.info('Default provider initialized and ready');
     _emitEvent(
       OpenFeatureEventType.PROVIDER_READY,
       'Default provider ready',
+      provider: _provider,
       providerMetadata: _provider.metadata,
     );
   }
 
   Future<void> setProvider(FeatureProvider provider) async {
     _logger.info('Setting provider: ${provider.name}');
-
-    try {
-      if (provider.state == ProviderState.NOT_READY) {
-        await provider.initialize();
-      }
-
-      _provider = provider;
-      _providerRegistry[provider.metadata.name] = provider;
-      _providerStreamController.add(provider);
-
-      if (provider.state == ProviderState.READY) {
-        _emitEvent(
-          OpenFeatureEventType.PROVIDER_READY,
-          'Provider ready: ${provider.name}',
-          providerMetadata: provider.metadata,
-        );
-      } else {
-        _emitEvent(
-          OpenFeatureEventType.PROVIDER_ERROR,
-          'Provider not ready: ${provider.name}',
-          data: {'state': provider.state.name},
-          providerMetadata: provider.metadata,
-          errorCode: _errorCodeFrom(null, state: provider.state),
-        );
-      }
-    } catch (error) {
-      _logger.severe('Failed to initialize provider: $error');
-      _provider = provider;
-      _providerRegistry[provider.metadata.name] = provider;
-      _providerStreamController.add(provider);
-      _emitEvent(
-        OpenFeatureEventType.PROVIDER_ERROR,
-        'Provider initialization failed: ${provider.name}',
-        data: error,
-        providerMetadata: provider.metadata,
-        errorCode: _errorCodeFrom(error),
-      );
-    }
+    await _setDefaultProvider(provider, rethrowInitializationError: false);
   }
 
   /// Set provider and wait for it to be ready
   Future<void> setProviderAndWait(FeatureProvider provider) async {
     _logger.info('Setting provider and waiting: ${provider.name}');
+    await _setDefaultProvider(provider, rethrowInitializationError: true);
+  }
+
+  Future<void> _setDefaultProvider(
+    FeatureProvider provider, {
+    required bool rethrowInitializationError,
+  }) async {
+    final previousProvider = _provider;
+    Object? initializationError;
+    StackTrace? initializationStack;
 
     try {
-      if (provider.state == ProviderState.NOT_READY) {
-        await provider.initialize();
-      }
+      await _lifecycleManager.initialize(provider);
+    } catch (error, stackTrace) {
+      initializationError = error;
+      initializationStack = stackTrace;
+      _logger.severe('Failed to initialize provider: $error');
+    }
 
-      if (provider.state != ProviderState.READY) {
-        throw ProviderException(
-          'Provider failed to reach READY state: ${provider.state}',
-          code: ErrorCode.PROVIDER_NOT_READY,
+    if (!identical(previousProvider, provider)) {
+      _lifecycleManager.bindDefault(provider);
+      _provider = provider;
+      final registeredProvider = _providerRegistry[provider.metadata.name];
+      if (registeredProvider == null ||
+          identical(registeredProvider, previousProvider)) {
+        _providerRegistry[provider.metadata.name] = provider;
+        _activatePendingBindings(provider.metadata.name, provider);
+      }
+      _providerStreamController.add(provider);
+      try {
+        await _lifecycleManager.unbindDefault(previousProvider);
+      } catch (error) {
+        _logger.severe(
+          'Failed to shutdown replaced provider '
+          '${previousProvider.metadata.name}: $error',
+        );
+        _emitEvent(
+          OpenFeatureEventType.PROVIDER_ERROR,
+          'Replaced provider shutdown failed: ${previousProvider.name}',
+          data: error,
+          provider: previousProvider,
+          providerMetadata: previousProvider.metadata,
+          errorCode: _errorCodeFrom(error),
         );
       }
+    }
 
-      _provider = provider;
-      _providerRegistry[provider.metadata.name] = provider;
-      _providerStreamController.add(provider);
-      _emitEvent(
-        OpenFeatureEventType.PROVIDER_READY,
-        'Provider ready: ${provider.name}',
-        providerMetadata: provider.metadata,
+    if (initializationError != null && rethrowInitializationError) {
+      Error.throwWithStackTrace(
+        initializationError,
+        initializationStack ?? StackTrace.current,
       );
-    } catch (error) {
-      _logger.severe('Failed to initialize provider: $error');
-      _provider = provider;
-      _providerRegistry[provider.metadata.name] = provider;
-      _providerStreamController.add(provider);
-      _emitEvent(
-        OpenFeatureEventType.PROVIDER_ERROR,
-        'Provider initialization failed: ${provider.name}',
-        data: error,
-        providerMetadata: provider.metadata,
-        errorCode: _errorCodeFrom(error),
-      );
-      rethrow;
     }
   }
 
-  void registerProvider(FeatureProvider provider) {
-    _providerRegistry[provider.metadata.name] = provider;
+  /// Register a provider under an SDK identifier.
+  ///
+  /// The identifier defaults to provider metadata for backwards compatibility.
+  /// Callers registering same-name instances must supply distinct identifiers.
+  String registerProvider(FeatureProvider provider, {String? providerId}) {
+    final id = providerId ?? provider.metadata.name;
+    if (id.isEmpty) {
+      throw ArgumentError.value(id, 'providerId', 'must not be empty');
+    }
+    _lifecycleManager.statusOf(provider);
+    _providerRegistry[id] = provider;
+    _activatePendingBindings(id, provider);
+    return id;
   }
 
-  /// Shutdown the current provider (spec v0.8.0: status MUST indicate NOT_READY after shutdown)
+  void _activatePendingBindings(String providerId, FeatureProvider provider) {
+    final pendingDomains = _domainProviderIds.entries
+        .where(
+          (entry) =>
+              entry.value == providerId &&
+              !_domainProviderBindings.containsKey(entry.key),
+        )
+        .map((entry) => entry.key)
+        .toList();
+
+    for (final domain in pendingDomains) {
+      unawaited(
+        _bindDomainProvider(domain, providerId, provider).catchError((
+          Object error,
+        ) {
+          _logger.severe('Failed to activate provider $providerId: $error');
+        }),
+      );
+      unawaited(
+        _lifecycleManager.initialize(provider).catchError((Object error) {
+          _logger.severe('Failed to initialize provider $providerId: $error');
+        }),
+      );
+    }
+  }
+
+  Future<String> registerProviderAndWait(
+    FeatureProvider provider, {
+    String? providerId,
+  }) async {
+    final id = registerProvider(provider, providerId: providerId);
+    await _lifecycleManager.initialize(provider);
+    return id;
+  }
+
+  /// Shutdown the current provider after its final binding is removed.
   Future<void> shutdownProvider() async {
     _logger.info('Shutting down provider: ${_provider.name}');
+    final provider = _provider;
 
     try {
-      await _provider.shutdown();
-      _emitEvent(
-        OpenFeatureEventType.PROVIDER_STALE,
-        'Provider shutdown: ${_provider.name}',
-        providerMetadata: _provider.metadata,
-      );
+      await _lifecycleManager.unbindDefault(provider);
     } catch (e) {
       _logger.severe('Error during provider shutdown: $e');
       _emitEvent(
         OpenFeatureEventType.PROVIDER_ERROR,
-        'Provider shutdown failed: ${_provider.name}',
+        'Provider shutdown failed: ${provider.name}',
         data: e,
-        providerMetadata: _provider.metadata,
+        provider: provider,
+        providerMetadata: provider.metadata,
         errorCode: _errorCodeFrom(e),
       );
     }
@@ -320,6 +352,11 @@ class OpenFeatureAPI {
 
   FeatureProvider _resolveProviderForClient(String clientId, String? domain) {
     final bindingKey = domain ?? clientId;
+    final directlyBoundProvider = _domainProviderBindings[bindingKey];
+    if (directlyBoundProvider != null) {
+      return directlyBoundProvider;
+    }
+
     final boundProviderName = _domainManager.getProviderForClient(bindingKey);
     if (boundProviderName == null) {
       return _provider;
@@ -330,7 +367,9 @@ class OpenFeatureAPI {
 
   /// Get or create a client
   FeatureClient getClient(String name, {String? domain}) {
-    final selectedProvider = _resolveProviderForClient(name, domain);
+    FeatureProvider resolveProvider() =>
+        _resolveProviderForClient(name, domain);
+    final selectedProvider = resolveProvider();
 
     final hookManager = HookManager();
     for (final hook in _hooks) {
@@ -345,6 +384,8 @@ class OpenFeatureAPI {
           : const EvaluationContext(attributes: {}),
       defaultContext: const EvaluationContext(attributes: {}),
       provider: selectedProvider,
+      providerResolver: resolveProvider,
+      providerStatusResolver: _lifecycleManager.statusOf,
       eventStream: events,
     );
   }
@@ -356,12 +397,15 @@ class OpenFeatureAPI {
 
   FeatureProvider get provider => _provider;
 
+  ProviderState get providerStatus => _lifecycleManager.statusOf(_provider);
+
   void setGlobalContext(OpenFeatureEvaluationContext context) {
     _logger.info('Setting global context');
     _globalContext = context;
     _emitEvent(
       OpenFeatureEventType.PROVIDER_CONTEXT_CHANGED,
       'Global context updated',
+      provider: _provider,
       providerMetadata: _provider.metadata,
     );
   }
@@ -382,12 +426,93 @@ class OpenFeatureAPI {
       handler.cancel();
 
   void bindClientToProvider(String clientId, String providerId) {
-    _domainManager.bindClientToProvider(clientId, providerId);
+    final provider = _providerRegistry[providerId];
+    if (provider == null) {
+      // Preserve the legacy name-first binding flow. Once a provider is
+      // registered under this identifier, clients resolve it dynamically.
+      _domainProviderIds[clientId] = providerId;
+      _domainManager.bindClientToProvider(clientId, providerId);
+      _emitEvent(
+        OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED,
+        'Domain $clientId bound to pending provider $providerId',
+        domain: clientId,
+      );
+      return;
+    }
+
+    unawaited(
+      _bindDomainProvider(clientId, providerId, provider).catchError((
+        Object error,
+      ) {
+        _logger.severe('Failed to bind provider $providerId: $error');
+      }),
+    );
+    unawaited(
+      _lifecycleManager.initialize(provider).catchError((Object error) {
+        _logger.severe('Failed to initialize provider $providerId: $error');
+      }),
+    );
+  }
+
+  Future<void> bindClientToProviderAndWait(
+    String clientId,
+    String providerId,
+  ) async {
+    final provider = _providerRegistry[providerId];
+    if (provider == null) {
+      throw ArgumentError.value(providerId, 'providerId', 'is not registered');
+    }
+
+    await _lifecycleManager.initialize(provider);
+    await _bindDomainProvider(clientId, providerId, provider);
+  }
+
+  Future<void> setProviderForDomainAndWait(
+    String domain,
+    FeatureProvider provider, {
+    String? providerId,
+  }) async {
+    final id = registerProvider(provider, providerId: providerId);
+    await _lifecycleManager.initialize(provider);
+    await _bindDomainProvider(domain, id, provider);
+  }
+
+  Future<void> _bindDomainProvider(
+    String domain,
+    String providerId,
+    FeatureProvider provider,
+  ) async {
+    final previousProvider = _domainProviderBindings[domain];
+    _lifecycleManager.bindDomain(provider, domain);
+    _domainProviderBindings[domain] = provider;
+    _domainProviderIds[domain] = providerId;
+    _domainManager.bindClientToProvider(domain, providerId);
     _emitEvent(
       OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED,
-      'Client $clientId bound to provider $providerId',
-      providerMetadata: _providerRegistry[providerId]?.metadata,
+      'Domain $domain bound to provider $providerId',
+      provider: provider,
+      domain: domain,
+      providerMetadata: provider.metadata,
     );
+
+    if (previousProvider != null && !identical(previousProvider, provider)) {
+      try {
+        await _lifecycleManager.unbindDomain(previousProvider, domain);
+      } catch (error) {
+        _logger.severe(
+          'Failed to shutdown provider removed from $domain: $error',
+        );
+        _emitEvent(
+          OpenFeatureEventType.PROVIDER_ERROR,
+          'Provider shutdown failed after removal from $domain',
+          data: error,
+          provider: previousProvider,
+          providerMetadata: previousProvider.metadata,
+          domain: domain,
+          errorCode: _errorCodeFrom(error),
+        );
+      }
+    }
   }
 
   /// @deprecated Use getClient().getBooleanFlag() instead
@@ -406,25 +531,62 @@ class OpenFeatureAPI {
     );
   }
 
+  void _handleProviderLifecycleEvent(
+    FeatureProvider provider,
+    ProviderLifecycleEvent event,
+  ) {
+    final eventType = switch (event.type) {
+      ProviderLifecycleEventType.PROVIDER_READY =>
+        OpenFeatureEventType.PROVIDER_READY,
+      ProviderLifecycleEventType.PROVIDER_ERROR =>
+        OpenFeatureEventType.PROVIDER_ERROR,
+      ProviderLifecycleEventType.PROVIDER_CONFIGURATION_CHANGED =>
+        OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED,
+      ProviderLifecycleEventType.PROVIDER_STALE =>
+        OpenFeatureEventType.PROVIDER_STALE,
+      ProviderLifecycleEventType.PROVIDER_CONTEXT_CHANGED =>
+        OpenFeatureEventType.PROVIDER_CONTEXT_CHANGED,
+      ProviderLifecycleEventType.PROVIDER_RECONCILING =>
+        OpenFeatureEventType.PROVIDER_RECONCILING,
+    };
+
+    _emitEvent(
+      eventType,
+      event.message,
+      data: event.data,
+      provider: provider,
+      providerMetadata: provider.metadata,
+      errorCode: event.errorCode,
+      timestamp: event.timestamp,
+    );
+  }
+
   void _emitEvent(
     OpenFeatureEventType type,
     String message, {
     dynamic data,
+    FeatureProvider? provider,
     ProviderMetadata? providerMetadata,
+    String? domain,
     ErrorCode? errorCode,
+    DateTime? timestamp,
   }) {
     final event = OpenFeatureEvent(
       type,
       message,
       data: data,
+      provider: provider,
       providerMetadata: providerMetadata,
+      domain: domain,
       errorCode: errorCode,
+      timestamp: timestamp,
     );
     _eventStreamController.add(event);
   }
 
   Future<void> dispose() async {
     await _domainSubscription?.cancel();
+    await _lifecycleManager.dispose();
     _domainManager.dispose();
     await _providerStreamController.close();
     await _eventStreamController.close();

--- a/lib/open_feature_event.dart
+++ b/lib/open_feature_event.dart
@@ -16,6 +16,8 @@ class OpenFeatureEvent {
   final dynamic data;
   final DateTime timestamp;
   final ProviderMetadata? providerMetadata;
+  final FeatureProvider? provider;
+  final String? domain;
   final ErrorCode? errorCode;
 
   OpenFeatureEvent(
@@ -23,6 +25,9 @@ class OpenFeatureEvent {
     this.message, {
     this.data,
     this.providerMetadata,
+    this.provider,
+    this.domain,
     this.errorCode,
-  }) : timestamp = DateTime.now();
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
 }

--- a/lib/provider_lifecycle.dart
+++ b/lib/provider_lifecycle.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'feature_provider.dart';
+
+/// Lifecycle event types emitted by v0.9-capable providers.
+enum ProviderLifecycleEventType {
+  PROVIDER_READY,
+  PROVIDER_ERROR,
+  PROVIDER_CONFIGURATION_CHANGED,
+  PROVIDER_STALE,
+  PROVIDER_CONTEXT_CHANGED,
+  PROVIDER_RECONCILING,
+}
+
+/// A lifecycle event emitted directly by a feature provider.
+class ProviderLifecycleEvent {
+  final ProviderLifecycleEventType type;
+  final String message;
+  final dynamic data;
+  final ErrorCode? errorCode;
+  final DateTime timestamp;
+
+  ProviderLifecycleEvent(
+    this.type,
+    this.message, {
+    this.data,
+    this.errorCode,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+}
+
+/// Optional capability for providers that own their v0.9 lifecycle events.
+///
+/// Providers implementing this interface must emit
+/// [ProviderLifecycleEventType.PROVIDER_READY] before initialization returns
+/// normally and [ProviderLifecycleEventType.PROVIDER_ERROR] before it returns
+/// abnormally. Providers that do not implement this interface use the
+/// deprecated legacy lifecycle adapter, which derives events from lifecycle
+/// return values.
+abstract interface class ProviderEventSource {
+  Stream<ProviderLifecycleEvent> get providerEvents;
+}
+
+/// Marker for provider instances that can be bound to only one domain.
+abstract interface class DomainScopedProvider {}

--- a/lib/src/provider_lifecycle_manager.dart
+++ b/lib/src/provider_lifecycle_manager.dart
@@ -1,0 +1,357 @@
+import 'dart:async';
+import 'dart:collection';
+
+import '../feature_provider.dart';
+import '../provider_lifecycle.dart';
+
+typedef ProviderLifecycleEventHandler =
+    void Function(FeatureProvider provider, ProviderLifecycleEvent event);
+
+/// Coordinates provider lifecycle by provider instance.
+///
+/// Providers implementing [ProviderEventSource] own their lifecycle events.
+/// Providers without that capability are supported by a deprecated compatibility
+/// path that derives ready/error events from lifecycle return values and state.
+class ProviderLifecycleManager {
+  final ProviderLifecycleEventHandler _onProviderEvent;
+  final HashMap<FeatureProvider, _ProviderLifecycleRecord> _records =
+      HashMap.identity();
+
+  ProviderLifecycleManager(this._onProviderEvent);
+
+  _ProviderLifecycleRecord _recordFor(FeatureProvider provider) {
+    return _records.putIfAbsent(provider, () {
+      final record = _ProviderLifecycleRecord(
+        status: _normalizeState(provider.state),
+        usesLegacyLifecycle: provider is! ProviderEventSource,
+      );
+
+      if (provider case final ProviderEventSource eventSource) {
+        record.eventSubscription = eventSource.providerEvents.listen(
+          (event) => _handleProviderEvent(provider, record, event),
+        );
+      }
+
+      return record;
+    });
+  }
+
+  ProviderState statusOf(FeatureProvider provider) =>
+      _recordFor(provider).status;
+
+  bool usesLegacyLifecycle(FeatureProvider provider) =>
+      _recordFor(provider).usesLegacyLifecycle;
+
+  void bindDefault(FeatureProvider provider) {
+    _recordFor(provider).defaultBinding = true;
+  }
+
+  void bindDomain(FeatureProvider provider, String domain) {
+    final record = _recordFor(provider);
+    if (provider is DomainScopedProvider &&
+        record.domains.isNotEmpty &&
+        !record.domains.contains(domain)) {
+      throw ProviderException(
+        'Domain-scoped provider ${provider.metadata.name} is already bound to '
+        '${record.domains.first}.',
+        code: ErrorCode.INVALID_CONTEXT,
+        details: {'domain': domain, 'boundDomains': record.domains.toList()},
+      );
+    }
+    record.domains.add(domain);
+  }
+
+  Future<void> unbindDefault(FeatureProvider provider) async {
+    final record = _recordFor(provider);
+    record.defaultBinding = false;
+    await _shutdownAfterFinalUse(provider, record);
+  }
+
+  Future<void> unbindDomain(FeatureProvider provider, String domain) async {
+    final record = _recordFor(provider);
+    record.domains.remove(domain);
+    await _shutdownAfterFinalUse(provider, record);
+  }
+
+  Future<void> initialize(FeatureProvider provider) {
+    final record = _recordFor(provider);
+    if (record.status == ProviderState.READY &&
+        (!record.usesLegacyLifecycle || record.lifecycleObserved)) {
+      return Future.value();
+    }
+
+    final activeInitialization = record.initialization;
+    if (activeInitialization != null) {
+      return activeInitialization;
+    }
+
+    final initialization = record.usesLegacyLifecycle
+        ? _initializeLegacyProvider(provider, record)
+        : _initializeEventProvider(provider, record);
+    record.initialization = initialization;
+    return initialization.whenComplete(() {
+      record.initialization = null;
+    });
+  }
+
+  Future<void> _initializeLegacyProvider(
+    FeatureProvider provider,
+    _ProviderLifecycleRecord record,
+  ) async {
+    var errorEventEmitted = false;
+    try {
+      if (provider.state == ProviderState.NOT_READY) {
+        await provider.initialize();
+      }
+
+      record.status = _normalizeState(provider.state);
+      if (record.status == ProviderState.READY) {
+        _onProviderEvent(
+          provider,
+          ProviderLifecycleEvent(
+            ProviderLifecycleEventType.PROVIDER_READY,
+            'Provider ready: ${provider.name}',
+          ),
+        );
+        record.lifecycleObserved = true;
+        return;
+      }
+
+      final errorCode = _errorCodeForState(record.status);
+      record.status = errorCode == ErrorCode.PROVIDER_FATAL
+          ? ProviderState.FATAL
+          : ProviderState.ERROR;
+      _onProviderEvent(
+        provider,
+        ProviderLifecycleEvent(
+          ProviderLifecycleEventType.PROVIDER_ERROR,
+          'Provider not ready: ${provider.name}',
+          data: {'state': record.status.name, 'legacyLifecycle': true},
+          errorCode: errorCode,
+        ),
+      );
+      record.lifecycleObserved = true;
+      errorEventEmitted = true;
+      throw ProviderException(
+        'Provider failed to reach READY state: ${record.status.name}',
+        code: errorCode ?? ErrorCode.PROVIDER_NOT_READY,
+      );
+    } catch (error) {
+      if (!errorEventEmitted) {
+        record.status = _statusForError(error, provider.state);
+        _onProviderEvent(
+          provider,
+          ProviderLifecycleEvent(
+            ProviderLifecycleEventType.PROVIDER_ERROR,
+            'Provider initialization failed: ${provider.name}',
+            data: {'error': error, 'legacyLifecycle': true},
+            errorCode: _errorCodeForError(error, record.status),
+          ),
+        );
+        record.lifecycleObserved = true;
+      }
+      rethrow;
+    }
+  }
+
+  Future<void> _initializeEventProvider(
+    FeatureProvider provider,
+    _ProviderLifecycleRecord record,
+  ) async {
+    if (provider.state != ProviderState.NOT_READY) {
+      throw ProviderException(
+        'Provider is not ready for initialization: ${record.status.name}',
+        code: _errorCodeForState(record.status) ?? ErrorCode.PROVIDER_NOT_READY,
+      );
+    }
+
+    final signal = Completer<ProviderLifecycleEvent>();
+    record.initializationSignal = signal;
+
+    Object? initializationError;
+    StackTrace? initializationStack;
+    try {
+      await provider.initialize();
+    } catch (error, stackTrace) {
+      initializationError = error;
+      initializationStack = stackTrace;
+    }
+
+    // Provider events can use an asynchronous stream controller. Yield once so
+    // an event emitted before initialize returned can reach the SDK listener.
+    await Future<void>.delayed(Duration.zero);
+    record.initializationSignal = null;
+
+    if (!signal.isCompleted) {
+      Error.throwWithStackTrace(
+        ProviderException(
+          'Provider ${provider.metadata.name} did not emit a lifecycle event '
+          'before initialization completed.',
+          code: ErrorCode.GENERAL,
+          details: {
+            'expected': initializationError == null
+                ? ProviderLifecycleEventType.PROVIDER_READY.name
+                : ProviderLifecycleEventType.PROVIDER_ERROR.name,
+            if (initializationError != null)
+              'initializationError': initializationError,
+          },
+        ),
+        initializationStack ?? StackTrace.current,
+      );
+    }
+
+    final event = await signal.future;
+    if (initializationError != null) {
+      if (event.type != ProviderLifecycleEventType.PROVIDER_ERROR) {
+        throw ProviderException(
+          'Provider ${provider.metadata.name} emitted ${event.type.name} after '
+          'initialization failed.',
+          code: ErrorCode.GENERAL,
+        );
+      }
+      Error.throwWithStackTrace(
+        initializationError,
+        initializationStack ?? StackTrace.current,
+      );
+    }
+
+    if (event.type != ProviderLifecycleEventType.PROVIDER_READY ||
+        record.status != ProviderState.READY) {
+      throw ProviderException(
+        event.message,
+        code:
+            event.errorCode ??
+            _errorCodeForState(record.status) ??
+            ErrorCode.PROVIDER_NOT_READY,
+        details: event.data is Map<String, dynamic>
+            ? event.data as Map<String, dynamic>
+            : null,
+      );
+    }
+  }
+
+  void _handleProviderEvent(
+    FeatureProvider provider,
+    _ProviderLifecycleRecord record,
+    ProviderLifecycleEvent event,
+  ) {
+    record.status = _statusForEvent(event, record.status);
+    record.lifecycleObserved = true;
+    final signal = record.initializationSignal;
+    if (signal != null &&
+        !signal.isCompleted &&
+        (event.type == ProviderLifecycleEventType.PROVIDER_READY ||
+            event.type == ProviderLifecycleEventType.PROVIDER_ERROR)) {
+      signal.complete(event);
+    }
+
+    // Status is updated before the API dispatches the event to handlers.
+    _onProviderEvent(provider, event);
+  }
+
+  Future<void> _shutdownAfterFinalUse(
+    FeatureProvider provider,
+    _ProviderLifecycleRecord record,
+  ) async {
+    if (record.defaultBinding || record.domains.isNotEmpty) {
+      return;
+    }
+
+    final activeShutdown = record.shutdown;
+    if (activeShutdown != null) {
+      return activeShutdown;
+    }
+
+    final shutdown = _shutdownProvider(provider, record);
+    record.shutdown = shutdown;
+    await shutdown.whenComplete(() {
+      record.shutdown = null;
+    });
+  }
+
+  Future<void> _shutdownProvider(
+    FeatureProvider provider,
+    _ProviderLifecycleRecord record,
+  ) async {
+    await provider.shutdown();
+    // Shutdown is the one lifecycle transition inferred by the SDK in v0.9.
+    record.status = ProviderState.NOT_READY;
+  }
+
+  Future<void> dispose() async {
+    for (final record in _records.values) {
+      await record.eventSubscription?.cancel();
+    }
+    _records.clear();
+  }
+
+  static ProviderState _normalizeState(ProviderState state) {
+    return switch (state) {
+      ProviderState.SHUTDOWN => ProviderState.NOT_READY,
+      ProviderState.PLUGIN_ERROR => ProviderState.ERROR,
+      _ => state,
+    };
+  }
+
+  static ProviderState _statusForEvent(
+    ProviderLifecycleEvent event,
+    ProviderState currentStatus,
+  ) {
+    return switch (event.type) {
+      ProviderLifecycleEventType.PROVIDER_READY => ProviderState.READY,
+      ProviderLifecycleEventType.PROVIDER_ERROR =>
+        event.errorCode == ErrorCode.PROVIDER_FATAL
+            ? ProviderState.FATAL
+            : ProviderState.ERROR,
+      ProviderLifecycleEventType.PROVIDER_STALE => ProviderState.STALE,
+      ProviderLifecycleEventType.PROVIDER_CONTEXT_CHANGED =>
+        ProviderState.READY,
+      ProviderLifecycleEventType.PROVIDER_RECONCILING =>
+        ProviderState.SYNCHRONIZING,
+      ProviderLifecycleEventType.PROVIDER_CONFIGURATION_CHANGED =>
+        currentStatus,
+    };
+  }
+
+  static ProviderState _statusForError(Object error, ProviderState state) {
+    if (error is ProviderException && error.code == ErrorCode.PROVIDER_FATAL) {
+      return ProviderState.FATAL;
+    }
+    final normalized = _normalizeState(state);
+    return normalized == ProviderState.FATAL
+        ? ProviderState.FATAL
+        : ProviderState.ERROR;
+  }
+
+  static ErrorCode? _errorCodeForState(ProviderState state) {
+    return switch (state) {
+      ProviderState.FATAL => ErrorCode.PROVIDER_FATAL,
+      ProviderState.READY => null,
+      _ => ErrorCode.PROVIDER_NOT_READY,
+    };
+  }
+
+  static ErrorCode _errorCodeForError(Object error, ProviderState state) {
+    if (error is ProviderException) {
+      return error.code;
+    }
+    return _errorCodeForState(state) ?? ErrorCode.GENERAL;
+  }
+}
+
+class _ProviderLifecycleRecord {
+  ProviderState status;
+  final bool usesLegacyLifecycle;
+  bool lifecycleObserved = false;
+  bool defaultBinding = false;
+  final Set<String> domains = {};
+  StreamSubscription<ProviderLifecycleEvent>? eventSubscription;
+  Completer<ProviderLifecycleEvent>? initializationSignal;
+  Future<void>? initialization;
+  Future<void>? shutdown;
+
+  _ProviderLifecycleRecord({
+    required this.status,
+    required this.usesLegacyLifecycle,
+  });
+}

--- a/test/provider_lifecycle_test.dart
+++ b/test/provider_lifecycle_test.dart
@@ -1,0 +1,455 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import '../lib/feature_provider.dart';
+import '../lib/open_feature_api.dart';
+import '../lib/open_feature_event.dart';
+import '../lib/provider_lifecycle.dart';
+
+class _LegacyProvider implements FeatureProvider {
+  final String providerName;
+  final Map<String, dynamic> flags;
+  ProviderState _state;
+  int initializeCount = 0;
+  int shutdownCount = 0;
+
+  _LegacyProvider(
+    this.flags, {
+    this.providerName = 'provider',
+    ProviderState initialState = ProviderState.NOT_READY,
+  }) : _state = initialState;
+
+  @override
+  String get name => providerName;
+
+  @override
+  ProviderState get state => _state;
+
+  @override
+  ProviderConfig get config => const ProviderConfig();
+
+  @override
+  ProviderMetadata get metadata => ProviderMetadata(name: providerName);
+
+  @override
+  Future<void> initialize([Map<String, dynamic>? config]) async {
+    initializeCount++;
+    _state = ProviderState.READY;
+  }
+
+  @override
+  Future<void> connect() async {
+    _state = ProviderState.READY;
+  }
+
+  @override
+  Future<void> shutdown() async {
+    shutdownCount++;
+    _state = ProviderState.SHUTDOWN;
+  }
+
+  @override
+  Future<FlagEvaluationResult<bool>> getBooleanFlag(
+    String flagKey,
+    bool defaultValue, {
+    Map<String, dynamic>? context,
+  }) async {
+    final value = flags[flagKey];
+    if (value is bool) {
+      return _result(flagKey, value);
+    }
+    return FlagEvaluationResult.error(
+      flagKey,
+      defaultValue,
+      value == null ? ErrorCode.FLAG_NOT_FOUND : ErrorCode.TYPE_MISMATCH,
+      'Boolean flag not found.',
+      evaluatorId: name,
+    );
+  }
+
+  @override
+  Future<FlagEvaluationResult<String>> getStringFlag(
+    String flagKey,
+    String defaultValue, {
+    Map<String, dynamic>? context,
+  }) async {
+    final value = flags[flagKey];
+    return value is String
+        ? _result(flagKey, value)
+        : FlagEvaluationResult.error(
+            flagKey,
+            defaultValue,
+            ErrorCode.FLAG_NOT_FOUND,
+            'String flag not found.',
+            evaluatorId: name,
+          );
+  }
+
+  @override
+  Future<FlagEvaluationResult<int>> getIntegerFlag(
+    String flagKey,
+    int defaultValue, {
+    Map<String, dynamic>? context,
+  }) async {
+    final value = flags[flagKey];
+    return value is int
+        ? _result(flagKey, value)
+        : FlagEvaluationResult.error(
+            flagKey,
+            defaultValue,
+            ErrorCode.FLAG_NOT_FOUND,
+            'Integer flag not found.',
+            evaluatorId: name,
+          );
+  }
+
+  @override
+  Future<FlagEvaluationResult<double>> getDoubleFlag(
+    String flagKey,
+    double defaultValue, {
+    Map<String, dynamic>? context,
+  }) async {
+    final value = flags[flagKey];
+    return value is double
+        ? _result(flagKey, value)
+        : FlagEvaluationResult.error(
+            flagKey,
+            defaultValue,
+            ErrorCode.FLAG_NOT_FOUND,
+            'Double flag not found.',
+            evaluatorId: name,
+          );
+  }
+
+  @override
+  Future<FlagEvaluationResult<Map<String, dynamic>>> getObjectFlag(
+    String flagKey,
+    Map<String, dynamic> defaultValue, {
+    Map<String, dynamic>? context,
+  }) async {
+    final value = flags[flagKey];
+    return value is Map<String, dynamic>
+        ? _result(flagKey, value)
+        : FlagEvaluationResult.error(
+            flagKey,
+            defaultValue,
+            ErrorCode.FLAG_NOT_FOUND,
+            'Object flag not found.',
+            evaluatorId: name,
+          );
+  }
+
+  FlagEvaluationResult<T> _result<T>(String flagKey, T value) {
+    return FlagEvaluationResult<T>(
+      flagKey: flagKey,
+      value: value,
+      reason: 'STATIC',
+      evaluatedAt: DateTime.now(),
+      evaluatorId: name,
+    );
+  }
+
+  @override
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
+  }) async {}
+}
+
+class _EventProvider extends _LegacyProvider implements ProviderEventSource {
+  final StreamController<ProviderLifecycleEvent> _events =
+      StreamController<ProviderLifecycleEvent>.broadcast();
+  final bool emitReady;
+  final bool failInitialization;
+
+  _EventProvider(
+    super.flags, {
+    super.providerName,
+    this.emitReady = true,
+    this.failInitialization = false,
+  });
+
+  @override
+  Stream<ProviderLifecycleEvent> get providerEvents => _events.stream;
+
+  @override
+  Future<void> initialize([Map<String, dynamic>? config]) async {
+    initializeCount++;
+    if (failInitialization) {
+      _state = ProviderState.ERROR;
+      _events.add(
+        ProviderLifecycleEvent(
+          ProviderLifecycleEventType.PROVIDER_ERROR,
+          'Provider initialization failed.',
+          errorCode: ErrorCode.PROVIDER_FATAL,
+        ),
+      );
+      throw const ProviderException(
+        'Provider initialization failed.',
+        code: ErrorCode.PROVIDER_FATAL,
+      );
+    }
+
+    _state = ProviderState.READY;
+    if (emitReady) {
+      _events.add(
+        ProviderLifecycleEvent(
+          ProviderLifecycleEventType.PROVIDER_READY,
+          'Provider is ready.',
+        ),
+      );
+    }
+  }
+
+  void emit(ProviderLifecycleEvent event) => _events.add(event);
+}
+
+class _DomainScopedProvider extends _EventProvider
+    implements DomainScopedProvider {
+  _DomainScopedProvider(super.flags);
+}
+
+void main() {
+  group('OpenFeature v0.9 provider lifecycle', () {
+    setUp(() async {
+      OpenFeatureAPI.resetInstance();
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    tearDown(() async {
+      OpenFeatureAPI.resetInstance();
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    test('provider event updates status before API handlers run', () async {
+      final api = OpenFeatureAPI();
+      final provider = _EventProvider({'flag': true});
+      final observedStatuses = <ProviderState>[];
+      final events = <OpenFeatureEvent>[];
+      final subscription = api.events.listen((event) {
+        if (identical(event.provider, provider)) {
+          events.add(event);
+          observedStatuses.add(api.providerStatus);
+        }
+      });
+
+      await api.setProviderAndWait(provider);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(api.providerStatus, ProviderState.READY);
+      expect(events, hasLength(1));
+      expect(events.single.type, OpenFeatureEventType.PROVIDER_READY);
+      expect(observedStatuses, [ProviderState.READY]);
+      await subscription.cancel();
+    });
+
+    test(
+      'event-capable provider must emit before initialize returns',
+      () async {
+        final api = OpenFeatureAPI();
+        final provider = _EventProvider({'flag': true}, emitReady: false);
+        final lifecycleEvents = <OpenFeatureEvent>[];
+        final subscription = api.events.listen((event) {
+          if (identical(event.provider, provider)) {
+            lifecycleEvents.add(event);
+          }
+        });
+
+        await expectLater(
+          api.setProviderAndWait(provider),
+          throwsA(
+            isA<ProviderException>().having(
+              (error) => error.message,
+              'message',
+              contains('did not emit a lifecycle event'),
+            ),
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(identical(api.provider, provider), isTrue);
+        expect(api.providerStatus, ProviderState.NOT_READY);
+        expect(lifecycleEvents, isEmpty);
+        await subscription.cancel();
+      },
+    );
+
+    test('provider error event sets fatal status without synthesis', () async {
+      final api = OpenFeatureAPI();
+      final provider = _EventProvider({'flag': true}, failInitialization: true);
+      final events = <OpenFeatureEvent>[];
+      final subscription = api.events.listen((event) {
+        if (identical(event.provider, provider)) {
+          events.add(event);
+        }
+      });
+
+      await expectLater(
+        api.setProviderAndWait(provider),
+        throwsA(isA<ProviderException>()),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(api.providerStatus, ProviderState.FATAL);
+      expect(events, hasLength(1));
+      expect(events.single.type, OpenFeatureEventType.PROVIDER_ERROR);
+      expect(events.single.errorCode, ErrorCode.PROVIDER_FATAL);
+      await subscription.cancel();
+    });
+
+    test(
+      'legacy providers retain synthesized lifecycle compatibility',
+      () async {
+        final api = OpenFeatureAPI();
+        final provider = _LegacyProvider({'flag': true});
+        final events = <OpenFeatureEvent>[];
+        final subscription = api.events.listen((event) {
+          if (identical(event.provider, provider)) {
+            events.add(event);
+          }
+        });
+
+        await api.setProviderAndWait(provider);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(api.providerStatus, ProviderState.READY);
+        expect(events, hasLength(1));
+        expect(events.single.type, OpenFeatureEventType.PROVIDER_READY);
+        await subscription.cancel();
+      },
+    );
+
+    test('already-ready legacy provider still announces readiness', () async {
+      final api = OpenFeatureAPI();
+      final provider = _LegacyProvider({
+        'flag': true,
+      }, initialState: ProviderState.READY);
+      final events = <OpenFeatureEvent>[];
+      final subscription = api.events.listen((event) {
+        if (identical(event.provider, provider)) {
+          events.add(event);
+        }
+      });
+
+      await api.setProviderAndWait(provider);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.initializeCount, 0);
+      expect(events, hasLength(1));
+      expect(events.single.type, OpenFeatureEventType.PROVIDER_READY);
+      await subscription.cancel();
+    });
+
+    test('existing clients follow default provider replacement', () async {
+      final api = OpenFeatureAPI();
+      final first = _EventProvider({'flag': true}, providerName: 'shared');
+      final second = _EventProvider({'flag': false}, providerName: 'shared');
+
+      await api.setProviderAndWait(first);
+      final client = api.getClient('existing-client');
+      expect(await client.getBooleanFlag('flag'), isTrue);
+
+      await api.setProviderAndWait(second);
+
+      expect(identical(client.provider, second), isTrue);
+      expect(client.providerStatus, ProviderState.READY);
+      expect(await client.getBooleanFlag('flag'), isFalse);
+    });
+
+    test('same-name instances remain isolated by provider ID', () async {
+      final api = OpenFeatureAPI();
+      final first = _EventProvider({'flag': true}, providerName: 'shared');
+      final second = _EventProvider({'flag': false}, providerName: 'shared');
+
+      await api.registerProviderAndWait(first, providerId: 'shared-blue');
+      await api.registerProviderAndWait(second, providerId: 'shared-green');
+      await api.bindClientToProviderAndWait('blue', 'shared-blue');
+      await api.bindClientToProviderAndWait('green', 'shared-green');
+
+      final blue = api.getClient('blue', domain: 'blue');
+      final green = api.getClient('green', domain: 'green');
+      final blueEvents = <OpenFeatureEvent>[];
+      final greenEvents = <OpenFeatureEvent>[];
+      final blueSubscription = blue.events.listen(blueEvents.add);
+      final greenSubscription = green.events.listen(greenEvents.add);
+
+      expect(await blue.getBooleanFlag('flag'), isTrue);
+      expect(await green.getBooleanFlag('flag'), isFalse);
+
+      second.emit(
+        ProviderLifecycleEvent(
+          ProviderLifecycleEventType.PROVIDER_STALE,
+          'Green provider is stale.',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(blueEvents, isEmpty);
+      expect(greenEvents, hasLength(1));
+      expect(green.providerStatus, ProviderState.STALE);
+      await blueSubscription.cancel();
+      await greenSubscription.cancel();
+      await blue.dispose();
+      await green.dispose();
+    });
+
+    test('legacy name-first binding activates after registration', () async {
+      final api = OpenFeatureAPI();
+      api.bindClientToProvider('checkout', 'late-provider');
+      final client = api.getClient('checkout', domain: 'checkout');
+      final provider = _EventProvider({'flag': true});
+
+      await api.registerProviderAndWait(provider, providerId: 'late-provider');
+
+      expect(identical(client.provider, provider), isTrue);
+      expect(client.providerStatus, ProviderState.READY);
+      expect(provider.initializeCount, 1);
+      expect(await client.getBooleanFlag('flag'), isTrue);
+    });
+
+    test(
+      'provider shuts down only after its final binding is removed',
+      () async {
+        final api = OpenFeatureAPI();
+        final first = _EventProvider({'flag': true}, providerName: 'first');
+        final replacement = _EventProvider({
+          'flag': false,
+        }, providerName: 'replacement');
+
+        await api.setProviderAndWait(first);
+        api.registerProvider(first, providerId: 'first-domain');
+        await api.bindClientToProviderAndWait('checkout', 'first-domain');
+
+        await api.setProviderAndWait(replacement);
+        expect(first.shutdownCount, 0);
+
+        api.registerProvider(replacement, providerId: 'replacement-domain');
+        await api.bindClientToProviderAndWait('checkout', 'replacement-domain');
+
+        expect(first.shutdownCount, 1);
+        expect(replacement.shutdownCount, 0);
+      },
+    );
+
+    test('domain-scoped provider rejects a second domain', () async {
+      final api = OpenFeatureAPI();
+      final provider = _DomainScopedProvider({'flag': true});
+
+      await api.registerProviderAndWait(provider, providerId: 'scoped');
+      await api.bindClientToProviderAndWait('domain-a', 'scoped');
+
+      await expectLater(
+        api.bindClientToProviderAndWait('domain-b', 'scoped'),
+        throwsA(
+          isA<ProviderException>().having(
+            (error) => error.code,
+            'code',
+            ErrorCode.INVALID_CONTEXT,
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implement the first P0 server-conformance slice from #121 and draft matrix #122:

- add an opt-in `ProviderEventSource` contract for provider-owned v0.9 lifecycle events
- update SDK provider status before dispatching lifecycle events to handlers
- reject event-capable providers that return from initialization without the required ready/error event
- retain existing `FeatureProvider` implementations through the documented legacy lifecycle adapter
- track provider bindings by object identity rather than metadata name
- support distinct IDs for same-name provider instances
- make existing clients follow later default and domain provider replacements
- enforce `DomainScopedProvider` single-domain binding
- shut providers down once after their final default/domain binding is removed

## Compatibility

This PR does not add members to the existing `FeatureProvider` interface. Existing providers continue to work and receive synthesized legacy lifecycle events. Providers opt into the v0.9 behavior by additionally implementing `ProviderEventSource`.

Existing name-first `bindClientToProvider` behavior is preserved. New waiting APIs provide deterministic initialization and binding:

- `registerProviderAndWait`
- `bindClientToProviderAndWait`
- `setProviderForDomainAndWait`

The published package name, import paths, asynchronous evaluation model, dynamic invocation context, and pure Dart boundary remain unchanged.

## Specification coverage

This slice advances:

- 1.1.2.1-1.1.2.4: provider initialization, replacement, and final-use shutdown
- 1.1.3 and 1.1.8.1: domain binding and domain-scoped enforcement
- 1.7.1-1.7.6: provider status access and shutdown transition
- 2.8.1-2.8.5: provider-owned lifecycle events with legacy compatibility
- 5.1.2-5.1.5 and 5.3.1-5.3.3: instance-aware delivery and status-before-handler ordering

Evaluation defaults/context integrity and the remaining P0 rows stay in follow-up PRs.

## Validation

- `git diff --check origin/development..HEAD`
- `dart analyze` (no issues)
- `dart test` (143 tests passed: 133 existing + 10 lifecycle tests)
- `dart pub publish --dry-run` (0 warnings; no publication performed)

## Documentation

Provider migration guidance is included in `doc/provider-lifecycle-v0.9.md`.

Tracks #121.
Related proposal: #122.