### PR TITLE
fix(lifecycle): serialize provider rebinding

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -106,6 +106,12 @@ class FeatureClient {
       return;
     }
 
+    // Provider names are not unique. A dynamically bound client must not
+    // infer an event's source from metadata when no provider identity exists.
+    if (_providerResolver != null && event.providerMetadata != null) {
+      return;
+    }
+
     final eventProvider = event.providerMetadata?.name;
     if (eventProvider == null ||
         eventProvider == currentProvider.metadata.name) {

--- a/lib/src/provider_lifecycle_manager.dart
+++ b/lib/src/provider_lifecycle_manager.dart
@@ -83,6 +83,13 @@ class ProviderLifecycleManager {
 
   Future<void> initialize(FeatureProvider provider) {
     final record = _recordFor(provider);
+    final activeShutdown = record.shutdown;
+    if (activeShutdown != null) {
+      // A provider cannot be initialized safely until its prior binding has
+      // finished shutting down and its lifecycle record has been discarded.
+      return activeShutdown.then((_) => initialize(provider));
+    }
+
     if (record.status == ProviderState.READY &&
         (!record.usesLegacyLifecycle || record.lifecycleObserved)) {
       return Future.value();

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -507,6 +507,66 @@ void main() {
     });
 
     test(
+      'dynamic same-name clients reject ambiguous metadata-only events',
+      () async {
+        final controller = StreamController<OpenFeatureEvent>.broadcast();
+        final firstProvider = MockProvider({'test-flag': true});
+        final secondProvider = MockProvider({'test-flag': false});
+        final firstReceived = <OpenFeatureEvent>[];
+        final secondReceived = <OpenFeatureEvent>[];
+        final firstClient = FeatureClient(
+          metadata: ClientMetadata(name: 'first-client'),
+          hookManager: hookManager,
+          defaultContext: context,
+          provider: firstProvider,
+          providerResolver: () => firstProvider,
+          eventStream: controller.stream,
+        );
+        final secondClient = FeatureClient(
+          metadata: ClientMetadata(name: 'second-client'),
+          hookManager: hookManager,
+          defaultContext: context,
+          provider: secondProvider,
+          providerResolver: () => secondProvider,
+          eventStream: controller.stream,
+        );
+        final firstSub = firstClient.addHandler(firstReceived.add);
+        final secondSub = secondClient.addHandler(secondReceived.add);
+
+        controller.add(
+          OpenFeatureEvent(
+            OpenFeatureEventType.PROVIDER_STALE,
+            'ambiguous',
+            providerMetadata: firstProvider.metadata,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(firstReceived, isEmpty);
+        expect(secondReceived, isEmpty);
+
+        controller.add(
+          OpenFeatureEvent(
+            OpenFeatureEventType.PROVIDER_STALE,
+            'identified',
+            provider: firstProvider,
+            providerMetadata: firstProvider.metadata,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(firstReceived, hasLength(1));
+        expect(secondReceived, isEmpty);
+
+        await firstSub.cancel();
+        await secondSub.cancel();
+        await firstClient.dispose();
+        await secondClient.dispose();
+        await controller.close();
+      },
+    );
+
+    test(
       'provider error result triggers error hooks instead of after hooks',
       () async {
         final lifecycleHook = LifecycleHook();

--- a/test/provider_lifecycle_test.dart
+++ b/test/provider_lifecycle_test.dart
@@ -213,6 +213,23 @@ class _EventProvider extends _LegacyProvider implements ProviderEventSource {
   void emit(ProviderLifecycleEvent event) => _events.add(event);
 }
 
+class _DelayedShutdownEventProvider extends _EventProvider {
+  final Completer<void> shutdownStarted = Completer<void>();
+  final Completer<void> allowShutdown = Completer<void>();
+
+  _DelayedShutdownEventProvider(super.flags);
+
+  @override
+  Future<void> shutdown() async {
+    shutdownCount++;
+    if (!shutdownStarted.isCompleted) {
+      shutdownStarted.complete();
+    }
+    await allowShutdown.future;
+    _state = ProviderState.SHUTDOWN;
+  }
+}
+
 class _DomainScopedProvider extends _EventProvider
     implements DomainScopedProvider {
   _DomainScopedProvider(super.flags);
@@ -376,6 +393,32 @@ void main() {
       expect(identical(client.provider, second), isTrue);
       expect(client.providerStatus, ProviderState.READY);
       expect(await client.getBooleanFlag('flag'), isFalse);
+    });
+
+    test('rebinding waits for an in-progress provider shutdown', () async {
+      final api = OpenFeatureAPI();
+      final first = _DelayedShutdownEventProvider({'flag': true});
+      final second = _EventProvider({'flag': false});
+
+      await api.setProviderAndWait(first);
+      final replacement = api.setProviderAndWait(second);
+      await first.shutdownStarted.future;
+
+      var rebindCompleted = false;
+      final rebind = api.setProviderAndWait(first).then((_) {
+        rebindCompleted = true;
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect(rebindCompleted, isFalse);
+      expect(first.initializeCount, 1);
+
+      first.allowShutdown.complete();
+      await Future.wait([replacement, rebind]);
+
+      expect(first.initializeCount, 2);
+      expect(identical(api.provider, first), isTrue);
+      expect(api.providerStatus, ProviderState.READY);
     });
 
     test('same-name instances remain isolated by provider ID', () async {


### PR DESCRIPTION
## Summary
- serialize provider initialization behind an in-progress shutdown before rebinding
- reject ambiguous metadata-only provider events for dynamically bound clients
- add regressions for concurrent rebinding and same-name provider event routing

## Why
This addresses the two incremental CodeRabbit findings on the development-to-main promotion PR after #132 merged.

## QA
- Dart 3.12.2 stable
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test` (164 tests)
- shutdown/rebind regression repeated 10 times
- `dart test --coverage=coverage` (1187/1547, 76.73%)
- `dart pub downgrade`, `dart analyze`, `dart test` (164 tests)
- `dart doc --dry-run` (0 warnings, 0 errors)
- `dart pub publish --dry-run` (0 warnings)

Signed-off-by: ABC2015 <6826984+ABC2015@users.noreply.github.com>