### PR TITLE
fix(api): preserve latest domain binding

### DIFF
--- a/doc/provider-lifecycle-v0.9.md
+++ b/doc/provider-lifecycle-v0.9.md
@@ -43,10 +43,12 @@ Future<void> initialize([Map<String, dynamic>? config]) async {
 }
 ```
 
-The ready event must be emitted before `initialize` returns normally. The error
-event must be emitted before `initialize` terminates abnormally. The SDK does
-not synthesize a missing event for a provider that implements
-`ProviderEventSource`; `setProviderAndWait` fails with a contract error instead.
+The SDK subscribes before calling `initialize`. The corresponding ready or
+error event may be emitted during that call or delivered asynchronously within
+the SDK's bounded lifecycle-event timeout after it completes. The SDK does not
+synthesize a missing event for a provider that implements `ProviderEventSource`;
+`setProviderAndWait` fails with a contract error when the expected event does
+not arrive in time.
 
 Providers that do not implement `ProviderEventSource` continue to work through
 the legacy lifecycle adapter. That path derives ready/error events from

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -311,7 +311,7 @@ class OpenFeatureAPI {
         .where(
           (entry) =>
               entry.value == providerId &&
-              !_domainProviderBindings.containsKey(entry.key),
+              !identical(_domainProviderBindings[entry.key], provider),
         )
         .map((entry) => entry.key)
         .toList();

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -154,6 +154,7 @@ class OpenFeatureAPI {
   final Map<String, FeatureProvider> _providerRegistry = {};
   final Map<String, FeatureProvider> _domainProviderBindings = {};
   final Map<String, String> _domainProviderIds = {};
+  final Map<String, int> _domainBindingGenerations = {};
   final DomainManager _domainManager = DomainManager();
   late final ProviderLifecycleManager _lifecycleManager;
   final List<OpenFeatureHook> _hooks = [];
@@ -444,10 +445,10 @@ class OpenFeatureAPI {
 
   void bindClientToProvider(String clientId, String providerId) {
     final provider = _providerRegistry[providerId];
+    _recordDomainBindingRequest(clientId, providerId);
     if (provider == null) {
       // Preserve the legacy name-first binding flow. Once a provider is
       // registered under this identifier, clients resolve it dynamically.
-      _domainProviderIds[clientId] = providerId;
       _domainManager.bindClientToProvider(clientId, providerId);
       _emitEvent(
         OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED,
@@ -477,6 +478,7 @@ class OpenFeatureAPI {
       throw ArgumentError.value(providerId, 'providerId', 'is not registered');
     }
 
+    _recordDomainBindingRequest(clientId, providerId);
     await _initializeAndBindDomainProvider([clientId], providerId, provider);
   }
 
@@ -486,7 +488,14 @@ class OpenFeatureAPI {
     String? providerId,
   }) async {
     final id = registerProvider(provider, providerId: providerId);
+    _recordDomainBindingRequest(domain, id);
     await _initializeAndBindDomainProvider([domain], id, provider);
+  }
+
+  void _recordDomainBindingRequest(String domain, String providerId) {
+    _domainProviderIds[domain] = providerId;
+    _domainBindingGenerations[domain] =
+        (_domainBindingGenerations[domain] ?? 0) + 1;
   }
 
   Future<void> _initializeAndBindDomainProvider(
@@ -494,9 +503,18 @@ class OpenFeatureAPI {
     String providerId,
     FeatureProvider provider,
   ) async {
+    final requestGenerations = <String, int>{
+      for (final domain in domains)
+        domain: _domainBindingGenerations[domain] ?? 0,
+    };
     await _lifecycleManager.initialize(provider);
-    for (final domain in domains) {
-      await _bindDomainProvider(domain, providerId, provider);
+    for (final request in requestGenerations.entries) {
+      await _bindDomainProvider(
+        request.key,
+        providerId,
+        provider,
+        request.value,
+      );
     }
   }
 
@@ -504,7 +522,14 @@ class OpenFeatureAPI {
     String domain,
     String providerId,
     FeatureProvider provider,
+    int requestGeneration,
   ) async {
+    if (_domainProviderIds[domain] != providerId ||
+        _domainBindingGenerations[domain] != requestGeneration ||
+        !identical(_providerRegistry[providerId], provider)) {
+      return;
+    }
+
     final previousProvider = _domainProviderBindings[domain];
     _lifecycleManager.bindDomain(provider, domain);
     _domainProviderBindings[domain] = provider;

--- a/lib/provider_lifecycle.dart
+++ b/lib/provider_lifecycle.dart
@@ -32,11 +32,12 @@ class ProviderLifecycleEvent {
 /// Optional capability for providers that own their v0.9 lifecycle events.
 ///
 /// Providers implementing this interface must emit
-/// [ProviderLifecycleEventType.PROVIDER_READY] before initialization returns
-/// normally and [ProviderLifecycleEventType.PROVIDER_ERROR] before it returns
-/// abnormally. Providers that do not implement this interface use the
-/// deprecated legacy lifecycle adapter, which derives events from lifecycle
-/// return values.
+/// [ProviderLifecycleEventType.PROVIDER_READY] when initialization completes
+/// normally and [ProviderLifecycleEventType.PROVIDER_ERROR] when it completes
+/// abnormally. The event may be emitted during initialization or delivered
+/// asynchronously within the SDK's bounded lifecycle-event timeout afterward.
+/// Providers that do not implement this interface use the deprecated legacy
+/// lifecycle adapter, which derives events from lifecycle return values.
 abstract interface class ProviderEventSource {
   Stream<ProviderLifecycleEvent> get providerEvents;
 }

--- a/test/open_feature_api_test.dart
+++ b/test/open_feature_api_test.dart
@@ -147,6 +147,7 @@ class TestProvider implements FeatureProvider {
 class DelayedTestProvider extends TestProvider {
   final Completer<void> initializationStarted = Completer<void>();
   final Completer<void> allowInitialization = Completer<void>();
+  final Completer<void> initializationCompleted = Completer<void>();
 
   DelayedTestProvider(
     Map<String, dynamic> flags, {
@@ -160,6 +161,9 @@ class DelayedTestProvider extends TestProvider {
     }
     await allowInitialization.future;
     await super.initialize(config);
+    if (!initializationCompleted.isCompleted) {
+      initializationCompleted.complete();
+    }
   }
 }
 
@@ -352,6 +356,74 @@ void main() {
       expect(identical(client.provider, fastProvider), isTrue);
       expect(await client.getBooleanFlag('test'), isFalse);
     });
+
+    test(
+      'activates a pending provider over an existing domain binding',
+      () async {
+        final api = OpenFeatureAPI();
+        final originalProvider = TestProvider({
+          'test': true,
+        }, providerName: 'original-provider');
+        final replacementProvider = TestProvider({
+          'test': false,
+        }, providerName: 'replacement-provider');
+        api.registerProvider(originalProvider, providerId: 'original');
+        await api.bindClientToProviderAndWait('checkout', 'original');
+
+        api.bindClientToProvider('checkout', 'replacement');
+        final replacementBound = api.events.firstWhere(
+          (event) =>
+              event.type ==
+                  OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED &&
+              event.domain == 'checkout' &&
+              identical(event.provider, replacementProvider),
+        );
+        api.registerProvider(replacementProvider, providerId: 'replacement');
+        await replacementBound;
+
+        final client = api.getClient('checkout', domain: 'checkout');
+        expect(identical(client.provider, replacementProvider), isTrue);
+        expect(await client.getBooleanFlag('test'), isFalse);
+      },
+    );
+
+    test(
+      'latest registered provider instance wins during initialization',
+      () async {
+        final api = OpenFeatureAPI();
+        final originalProvider = TestProvider({
+          'test': true,
+        }, providerName: 'original-provider');
+        final slowProvider = DelayedTestProvider({
+          'test': true,
+        }, providerName: 'slow-provider');
+        final replacementProvider = TestProvider({
+          'test': false,
+        }, providerName: 'replacement-provider');
+        api.registerProvider(originalProvider, providerId: 'original');
+        await api.bindClientToProviderAndWait('checkout', 'original');
+        api.registerProvider(slowProvider, providerId: 'replacement');
+
+        api.bindClientToProvider('checkout', 'replacement');
+        await slowProvider.initializationStarted.future;
+        final replacementBound = api.events.firstWhere(
+          (event) =>
+              event.type ==
+                  OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED &&
+              event.domain == 'checkout' &&
+              identical(event.provider, replacementProvider),
+        );
+        api.registerProvider(replacementProvider, providerId: 'replacement');
+        await replacementBound;
+
+        slowProvider.allowInitialization.complete();
+        await slowProvider.initializationCompleted.future;
+
+        final client = api.getClient('checkout', domain: 'checkout');
+        expect(identical(client.provider, replacementProvider), isTrue);
+        expect(await client.getBooleanFlag('test'), isFalse);
+      },
+    );
 
     test('emits events on provider change', () async {
       final api = OpenFeatureAPI();

--- a/test/open_feature_api_test.dart
+++ b/test/open_feature_api_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:test/test.dart';
 import '../lib/open_feature_api.dart';
 import '../lib/feature_provider.dart';
@@ -140,6 +142,25 @@ class TestProvider implements FeatureProvider {
     Map<String, dynamic> defaultValue, {
     Map<String, dynamic>? context,
   }) async => throw UnimplementedError();
+}
+
+class DelayedTestProvider extends TestProvider {
+  final Completer<void> initializationStarted = Completer<void>();
+  final Completer<void> allowInitialization = Completer<void>();
+
+  DelayedTestProvider(
+    Map<String, dynamic> flags, {
+    required String providerName,
+  }) : super(flags, providerName: providerName);
+
+  @override
+  Future<void> initialize([Map<String, dynamic>? config]) async {
+    if (!initializationStarted.isCompleted) {
+      initializationStarted.complete();
+    }
+    await allowInitialization.future;
+    await super.initialize(config);
+  }
 }
 
 class TestHook extends OpenFeatureHook {
@@ -307,6 +328,29 @@ void main() {
         client.provider.metadata.name,
         equals(secondaryProvider.metadata.name),
       );
+    });
+
+    test('latest concurrent domain binding request wins', () async {
+      final api = OpenFeatureAPI();
+      final slowProvider = DelayedTestProvider({
+        'test': true,
+      }, providerName: 'slow-provider');
+      final fastProvider = TestProvider({
+        'test': false,
+      }, providerName: 'fast-provider');
+      api.registerProvider(slowProvider, providerId: 'slow');
+      api.registerProvider(fastProvider, providerId: 'fast');
+
+      final slowBinding = api.bindClientToProviderAndWait('checkout', 'slow');
+      await slowProvider.initializationStarted.future;
+      await api.bindClientToProviderAndWait('checkout', 'fast');
+
+      slowProvider.allowInitialization.complete();
+      await slowBinding;
+
+      final client = api.getClient('checkout', domain: 'checkout');
+      expect(identical(client.provider, fastProvider), isTrue);
+      expect(await client.getBooleanFlag('test'), isFalse);
     });
 
     test('emits events on provider change', () async {


### PR DESCRIPTION
## Summary
- make concurrent domain binding requests commit in request order so the latest request wins
- validate both the request generation and registered provider instance before binding
- document the bounded asynchronous lifecycle-event timeout
- add a deterministic out-of-order initialization regression

## Why
This addresses the two still-valid Copilot comments on #132. The third Copilot comment, shutdown/rebind serialization, was already addressed by #133.

## QA
- Dart 3.12.2 stable
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test` (165 tests)
- latest-binding race regression repeated 10 times
- `dart test --coverage=coverage` (1200/1561, 76.87%)
- `dart pub downgrade`, `dart analyze`, `dart test` (165 tests)
- `dart doc --dry-run` (0 warnings, 0 errors)
- `dart pub publish --dry-run` (0 warnings)

Signed-off-by: ABC2015 <6826984+ABC2015@users.noreply.github.com>