### PR TITLE
chore(dco): allow individual remediation commits

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,4 @@
+# Preserve shared branch history while allowing commit authors to repair an
+# omitted or mismatched sign-off in a later, explicitly signed commit.
+allowRemediationCommits:
+  individual: true


### PR DESCRIPTION
## Summary

- enable DCO's individual remediation-commit mechanism;
- preserve shared branch history when a GitHub-authored squash commit retains a contributor sign-off that does not match the squash author;
- keep third-party remediation disabled.

## Why

GitHub squash merges in this repository are authored as `ABC2015 <6826984+ABC2015@users.noreply.github.com>`, but the generated squash body can retain `Signed-off-by: Jeremy Andrews <jandrews@venturseed.com>`. Those commits pass DCO on the feature PR and then fail DCO on the later `development`-to-`main` promotion PR.

Rewriting the shared `development` branch would invalidate collaborators' history. DCO's individual remediation support lets the same commit author add the missing matching sign-off in a later explicit commit without weakening DCO or authorizing third-party sign-offs.

## Scope

This changes only `.github/dco.yml`. It does not skip DCO for members, disable DCO, or enable third-party remediation.

## Validation

- configuration matches the DCO app's documented `allowRemediationCommits.individual` schema;
- `git diff --check`;
- commit author and `Signed-off-by` identity match.

No GitHub issue applies; this repairs the repository's promotion workflow.