### PR TITLE
chore(dco): remediate PR 138 squash commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,6 +336,10 @@ To certify your contribution, you must add a `Signed-off-by` line to your commit
      ```
    - An additional contributor sign-off may be retained, but it does not
      replace the matching author sign-off.
+   - A green DCO check on the source pull request does not guarantee that a
+     GitHub-generated squash commit will pass DCO. Before selecting **Squash
+     and merge**, inspect the generated commit message and add the trailer for
+     the GitHub account that will author the squash commit.
 
 ---
 


### PR DESCRIPTION
## Summary

- add the exact individual DCO remediation for the GitHub-authored #138 squash commit
- document the merge-time sign-off check that source-branch DCO validation cannot perform

## Why

GitHub authored squash commit `d9ab9395316a901636a775e7749f05f19a137255` as `ABC2015 <6826984+ABC2015@users.noreply.github.com>`, but its message retained only Jeremy Andrews' source-commit sign-off. DCO therefore correctly requires an author-matching remediation.

This PR uses the remediation text emitted by the DCO check. It does not rewrite `development` history or weaken DCO enforcement.

## QA

- remediation commit author and committer: `ABC2015 <6826984+ABC2015@users.noreply.github.com>`
- exact author-matching `Signed-off-by` trailer present
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze` — no issues
- `dart test` — 181/181 passed
- `git diff --check`

## Merge requirement

When using **Squash and merge**, retain this exact trailer in the generated commit message:

```text
Signed-off-by: ABC2015 <6826984+ABC2015@users.noreply.github.com>
```

Follow-up to #138 and unblocker for #131.
