### PR TITLE
ci: allow Dependabot GitHub Actions branches

### DIFF
--- a/.github/workflows/validation-workflow.yml
+++ b/.github/workflows/validation-workflow.yml
@@ -24,6 +24,8 @@ jobs:
 
           if [[ "$BRANCH_NAME" =~ ^(development|main|release-please--branches--main--components--openfeature_dart_server_sdk)$ ]]; then
             echo "✅ Branch name '$BRANCH_NAME' is valid for a long-lived branch."
+          elif [[ "$BRANCH_NAME" =~ ^dependabot/github_actions/development/[A-Za-z0-9._/-]+$ ]]; then
+            echo "✅ Branch name '$BRANCH_NAME' is valid for a Dependabot GitHub Actions update."
           elif [[ "$BRANCH_NAME" =~ ^(feat|fix|hotfix|chore|test|refactor|release|admin|docs|ci)/[a-z0-9._-]+$ ]]; then
             echo "✅ Branch name '$BRANCH_NAME' follows the naming convention."
           else


### PR DESCRIPTION
## Summary

- allow the standard Dependabot GitHub Actions branch shape generated by this repository's `dependabot.yml`
- keep the exception limited to the configured `development` target and `github_actions` ecosystem
- preserve the existing branch rules for contributors and long-lived branches

## Why

Dependabot PRs #140, #141, and #142 each pass 17 checks but fail branch-name validation because their generated branches contain multiple path segments, for example:

```text
dependabot/github_actions/development/dart-lang/setup-dart-1.8.0
```

The current contributor regex intentionally permits only `<type>/<branch-name>`, so this adds a separate narrow automation rule instead of weakening the contributor convention.

## Validation

- all three current Dependabot branch names accepted
- wrong target branch rejected
- wrong package ecosystem rejected
- empty dependency path rejected
- `git diff --check`

This PR targets `development`. Do not merge it until documentation promotion PR #144 has landed in `main`, because #144 uses the live `development` branch as its head.