### PR TITLE
feat(client): add static-context Dart SDK

### DIFF
--- a/.github/workflows/contributor-workflow.yml
+++ b/.github/workflows/contributor-workflow.yml
@@ -1,4 +1,4 @@
-# This workflow analyzes the Dart Server SDK and an example project
+# This workflow analyzes each Dart package.
 
 name: Contributor Workflow
 
@@ -6,10 +6,18 @@ on:
   workflow_call: # Makes the workflow reusable
 
 jobs:
-  analyze-core:
-    name: Analyze Core Dart Server SDK
+  analyze-package:
+    name: Analyze ${{ matrix.package.name }} package
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - name: server
+            path: .
+          - name: client
+            path: packages/openfeature_dart_client_sdk
 
     steps:
       - name: Checkout Code
@@ -20,44 +28,43 @@ jobs:
         # with:
         #   sdk: stable   # (optional; stable is the default)
 
-      # Find the Dart package root (directory that has pubspec.yaml).
-      - name: Locate package root
-        id: pkg
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Prefer repo root if it has a pubspec.yaml, otherwise take the first match.
-          if [[ -f "pubspec.yaml" ]]; then
-            echo "dir=." >> "$GITHUB_OUTPUT"
-          else
-            PKG_DIR=$(git ls-files | grep -E '(^|/)(pubspec\.yaml)$' | head -n 1 | xargs -r dirname)
-            if [[ -z "${PKG_DIR:-}" ]]; then
-              echo "No pubspec.yaml found in repository." >&2
-              exit 1
-            fi
-            echo "dir=$PKG_DIR" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Using package dir: $(cat $GITHUB_OUTPUT)"
-
       - name: Install Dependencies
-        working-directory: ${{ steps.pkg.outputs.dir }}
+        working-directory: ${{ matrix.package.path }}
         run: |
-          echo "Installing dependencies for core SDK..."
+          echo "Installing dependencies for ${{ matrix.package.name }} SDK..."
           dart pub get
 
       - name: Check for Outdated Dependencies
-        working-directory: ${{ steps.pkg.outputs.dir }}
+        working-directory: ${{ matrix.package.path }}
         run: |
           echo "Checking for outdated dependencies..."
           dart pub outdated || true
 
       - name: Verify Dart Formatting
-        working-directory: ${{ steps.pkg.outputs.dir }}
+        working-directory: ${{ matrix.package.path }}
         run: dart format --output=none --set-exit-if-changed .
+
+      - name: Validate publication archive
+        working-directory: ${{ matrix.package.path }}
+        env:
+          PACKAGE_PATH: ${{ matrix.package.path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$PACKAGE_PATH" == "." ]]; then
+            PUBLISH_OUTPUT=$(dart pub publish --dry-run 2>&1)
+          else
+            PUBLISH_OUTPUT=$(dart ../../tool/stage_client_package.dart --dry-run 2>&1)
+          fi
+          echo "$PUBLISH_OUTPUT"
+          if [[ "$PACKAGE_PATH" == "." ]] && grep -q "packages/openfeature_dart_client_sdk" <<< "$PUBLISH_OUTPUT"; then
+            echo "The server package archive contains client package files." >&2
+            exit 1
+          fi
 
       - name: Run Static Analysis (capture and show)
         id: analyze
-        working-directory: ${{ steps.pkg.outputs.dir }}
+        working-directory: ${{ matrix.package.path }}
         shell: bash
         run: |
           set -o pipefail
@@ -71,7 +78,7 @@ jobs:
 
       - name: Categorize and Count Analysis Results
         if: always()
-        working-directory: ${{ steps.pkg.outputs.dir }}
+        working-directory: ${{ matrix.package.path }}
         shell: bash
         run: |
           echo "Categorizing analysis results..."
@@ -105,7 +112,7 @@ jobs:
 
       - name: Identify Specific Commits for Issues
         if: always()
-        working-directory: ${{ steps.pkg.outputs.dir }}
+        working-directory: ${{ matrix.package.path }}
         shell: bash
         run: |
           echo "Identifying specific commits for files mentioned by analyzer..."
@@ -130,13 +137,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: core-sdk-analysis
+          name: ${{ matrix.package.name }}-sdk-analysis
           path: |
-            ${{ steps.pkg.outputs.dir }}/analysis_report.txt
-            ${{ steps.pkg.outputs.dir }}/error_log.txt
-            ${{ steps.pkg.outputs.dir }}/info_report.txt
-            ${{ steps.pkg.outputs.dir }}/warning_report.txt
-            ${{ steps.pkg.outputs.dir }}/error_report.txt
+            ${{ matrix.package.path }}/analysis_report.txt
+            ${{ matrix.package.path }}/error_log.txt
+            ${{ matrix.package.path }}/info_report.txt
+            ${{ matrix.package.path }}/warning_report.txt
+            ${{ matrix.package.path }}/error_report.txt
           retention-days: 7
 
       # Fail the job if the analyzer actually failed.

--- a/.github/workflows/coverage-workflow.yml
+++ b/.github/workflows/coverage-workflow.yml
@@ -7,6 +7,14 @@ jobs:
   test-and-upload:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - name: server
+            path: .
+          - name: client
+            path: packages/openfeature_dart_client_sdk
 
     steps:
       - name: Checkout code
@@ -18,14 +26,17 @@ jobs:
           sdk: stable
 
       - name: Install dependencies
+        working-directory: ${{ matrix.package.path }}
         run: dart pub get
 
       - name: Run tests with coverage
+        working-directory: ${{ matrix.package.path }}
         run: |
           mkdir -p coverage
           dart test --coverage=coverage
 
       - name: Generate LCOV report
+        working-directory: ${{ matrix.package.path }}
         run: |
           dart run coverage:format_coverage \
             --in=coverage \
@@ -34,14 +45,30 @@ jobs:
             --report-on=lib \
             --packages=.dart_tool/package_config.json
 
+      - name: Verify client coverage threshold
+        if: matrix.package.name == 'client'
+        working-directory: ${{ matrix.package.path }}
+        shell: bash
+        run: |
+          awk -F: '
+            /^LF:/ { lines_found += $2 }
+            /^LH:/ { lines_hit += $2 }
+            END {
+              coverage = 100 * lines_hit / lines_found
+              printf "Client line coverage: %d/%d (%.2f%%)\n", lines_hit, lines_found, coverage
+              if (coverage < 95) exit 1
+            }
+          ' coverage/lcov.info
+
       - name: List coverage files
+        working-directory: ${{ matrix.package.path }}
         run: ls -al coverage
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: coverage-report
-          path: coverage/lcov.info
+          name: coverage-report-${{ matrix.package.name }}
+          path: ${{ matrix.package.path }}/coverage/lcov.info
 
   upload-coverage:
     runs-on: ubuntu-latest
@@ -52,18 +79,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Download coverage artifact
+      - name: Download server coverage artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: coverage-report
-          path: coverage
+          name: coverage-report-server
+          path: coverage/server
+
+      - name: Download client coverage artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: coverage-report-client
+          path: coverage/client
 
       - name: List coverage files after download
-        run: ls -al coverage
+        run: ls -al coverage/server coverage/client
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV__UPLOAD_TOKEN }} # omit for public repos if you want
           slug: open-feature/dart-server-sdk
-          files: coverage/lcov.info
+          files: coverage/server/lcov.info,coverage/client/lcov.info

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   test:
-    name: test
+    name: test (${{ matrix.package.name }}, ${{ matrix.os }}, Dart ${{ matrix.sdk }})
     # The development push already validates the exact promotion SHA. Keep
     # feature PR and merge-queue validation while avoiding duplicate runners.
     if: >-
@@ -37,6 +37,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         sdk: [3.12.2, stable, beta]
+        package:
+          - name: server
+            path: .
+          - name: client
+            path: packages/openfeature_dart_client_sdk
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
@@ -44,16 +49,19 @@ jobs:
           sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
+        working-directory: ${{ matrix.package.path }}
         run: dart pub get
 
       - name: Analyze
+        working-directory: ${{ matrix.package.path }}
         run: dart analyze
 
       - name: Run tests
+        working-directory: ${{ matrix.package.path }}
         run: dart test
 
   minimum-dependencies:
-    name: minimum dependencies
+    name: minimum dependencies (${{ matrix.package.name }})
     if: >-
       github.event_name != 'pull_request' ||
       (github.event.pull_request.draft == false &&
@@ -62,6 +70,14 @@ jobs:
          github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - name: server
+            path: .
+          - name: client
+            path: packages/openfeature_dart_client_sdk
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
@@ -69,10 +85,13 @@ jobs:
           sdk: 3.12.2
 
       - name: Install minimum dependencies
+        working-directory: ${{ matrix.package.path }}
         run: dart pub downgrade
 
       - name: Analyze
+        working-directory: ${{ matrix.package.path }}
         run: dart analyze
 
       - name: Run tests
+        working-directory: ${{ matrix.package.path }}
         run: dart test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,8 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+' # tag pattern on pub.dev: 'v{{version}'
+      - 'v[0-9]+.[0-9]+.[0-9]+' # Server tag: v{{version}}
+      - 'openfeature_dart_client_sdk-v*'
 
 jobs:
   publish:
@@ -14,7 +15,30 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
+      - name: Select package
+        id: package
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$TAG_NAME" == openfeature_dart_client_sdk-v* ]]; then
+            echo "directory=packages/openfeature_dart_client_sdk" >> "$GITHUB_OUTPUT"
+          else
+            echo "directory=." >> "$GITHUB_OUTPUT"
+          fi
       - name: Install dependencies
+        working-directory: ${{ steps.package.outputs.directory }}
         run: dart pub get
       - name: Publish
+        if: ${{ !startsWith(github.ref_name, 'openfeature_dart_client_sdk-v') }}
+        working-directory: ${{ steps.package.outputs.directory }}
         run: dart pub publish --force
+      - name: Publish client package
+        if: >-
+          ${{ startsWith(github.ref_name, 'openfeature_dart_client_sdk-v') &&
+              github.ref_name != 'openfeature_dart_client_sdk-v0.0.1-beta.1' }}
+        run: dart tool/stage_client_package.dart --publish
+      - name: Explain first client publication
+        if: ${{ github.ref_name == 'openfeature_dart_client_sdk-v0.0.1-beta.1' }}
+        run: |
+          echo "The first client prerelease requires the documented manual pub.dev bootstrap."

--- a/.github/workflows/validation-workflow.yml
+++ b/.github/workflows/validation-workflow.yml
@@ -22,7 +22,7 @@ jobs:
           echo "Validating branch name..."
           echo "Branch name: $BRANCH_NAME"
 
-          if [[ "$BRANCH_NAME" =~ ^(development|main|release-please--branches--main--components--openfeature_dart_server_sdk)$ ]]; then
+          if [[ "$BRANCH_NAME" =~ ^(development|main|release-please--branches--main--components--(openfeature_dart_server_sdk|openfeature_dart_client_sdk))$ ]]; then
             echo "✅ Branch name '$BRANCH_NAME' is valid for a long-lived branch."
           elif [[ "$BRANCH_NAME" =~ ^dependabot/github_actions/development/[A-Za-z0-9._/-]+$ ]]; then
             echo "✅ Branch name '$BRANCH_NAME' is valid for a Dependabot GitHub Actions update."

--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,2 @@
+/packages/
+/tool/

--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ favorite feature flag management tool.
 
 <!-- x-hide-in-docs-end -->
 
-## Dart client SDK proposal
+## Dart client SDK beta
 
-This repository also contains the design proposal for a separate, pure-Dart
-OpenFeature client SDK intended for Dart VM, Dart web, and Flutter consumers.
-The client SDK is not implemented or published yet. The existing server SDK
-remains independently versioned and published.
+This repository also contains the first beta implementation of a separate,
+pure-Dart OpenFeature client SDK. The client package supports Dart VM, Dart web,
+and Flutter consumers. The existing server SDK remains independently versioned
+and published.
 
+- See the [client package](packages/openfeature_dart_client_sdk/).
 - Read the [client SDK architecture](doc/client-sdk-architecture.md).
 - Review the
   [client SDK conformance matrix](doc/client-sdk-conformance-matrix.md).

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - packages/**

--- a/doc/client-sdk-architecture.md
+++ b/doc/client-sdk-architecture.md
@@ -68,13 +68,18 @@ that creates that directory, repository safety must ensure:
 
 - the root server package excludes `/packages/` from its publication archive;
 - CI discovers, analyzes, and tests every package explicitly;
-- `dart pub publish --dry-run` validates each package from its own directory;
+- `dart pub publish --dry-run` validates each package-specific archive;
 - archive-content checks fail if one package contains another package's source;
 - release and publish workflows route tags to the correct package directory.
 
 A root `.pubignore` that excludes `/packages/` is the minimum transitional
 server-archive protection. A Pub workspace may provide shared dependency
 resolution, but publishing remains package-specific.
+
+Pub applies the root `.pubignore` while it packages the nested client. The
+client publication command therefore stages only the client directory in a
+temporary location before it runs `dart pub publish`. CI and tag publication
+use the same staging command.
 
 Shared code should be extracted only when both packages require the same stable,
 specification-neutral contract. Candidate types include flag values, provider

--- a/doc/client-sdk-conformance-matrix.md
+++ b/doc/client-sdk-conformance-matrix.md
@@ -20,7 +20,7 @@ matrix update.
 - Specification baseline: OpenFeature v0.9.0
 - Initial prerelease: `0.0.1-beta.1`
 - First stable release: `0.0.1`
-- Status: proposed; not implemented
+- Status: initial beta contract implemented; full conformance is in progress
 
 ## Maturity Legend
 
@@ -119,8 +119,8 @@ Before the client package directory can reach `main`:
 
 - the root server archive excludes `/packages/`;
 - CI discovers and validates both root and nested packages;
-- each package passes analysis, tests, and `dart pub publish --dry-run` from its
-  own directory;
+- each package passes analysis, tests, and a package-specific
+  `dart pub publish --dry-run` archive check;
 - archive inspection proves the server package does not contain client source;
 - existing server tags remain in the `v0.0.x` format;
 - client tags use `openfeature_dart_client_sdk-v<version>`;

--- a/packages/openfeature_dart_client_sdk/.pubignore
+++ b/packages/openfeature_dart_client_sdk/.pubignore
@@ -1,0 +1,4 @@
+/.dart_tool/
+/build/
+/coverage/
+/pubspec.lock

--- a/packages/openfeature_dart_client_sdk/CHANGELOG.md
+++ b/packages/openfeature_dart_client_sdk/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.0.1-beta.1
+
+- Add the initial static-context client API, provider contract, and hooks.
+- Add immutable evaluation types and an in-memory test provider.

--- a/packages/openfeature_dart_client_sdk/LICENSE
+++ b/packages/openfeature_dart_client_sdk/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright OpenFeature Maintainers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/openfeature_dart_client_sdk/README.md
+++ b/packages/openfeature_dart_client_sdk/README.md
@@ -1,0 +1,69 @@
+# OpenFeature Dart Client SDK
+
+This package is the vendor-neutral OpenFeature SDK for Dart client
+applications. It uses the static-context paradigm. It has no Flutter or
+`dart:io` dependency.
+
+The package is in beta. The first beta defines the public client and provider
+contracts. It provides synchronous typed evaluation, hooks, ordered context
+changes, and an in-memory provider. Later beta changes will complete event
+handlers and the remaining conformance work before the first stable release.
+
+## Use the client
+
+```dart
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk.dart';
+
+Future<void> main() async {
+  final provider = InMemoryProvider({
+    'new-checkout': true,
+    'welcome-message': 'Hello',
+  });
+
+  await OpenFeatureAPI.instance.setProviderAndWait(provider);
+  await OpenFeatureAPI.instance.setEvaluationContextAndWait(
+    EvaluationContext(targetingKey: 'user-123'),
+  );
+
+  final client = OpenFeatureAPI.instance.getClient('checkout');
+  final enabled = client.getBooleanValue('new-checkout', false);
+  final message = client.getStringValue('welcome-message', 'Welcome');
+
+  print('$enabled: $message');
+  await OpenFeatureAPI.instance.shutdown();
+}
+```
+
+## Implement a provider
+
+Implement `FeatureProvider` with synchronous resolvers. A resolver must use
+local state. It must not perform network, file, or platform-channel I/O.
+
+Implement only the optional capabilities that the provider needs:
+
+- `InitializableProvider` for asynchronous initialization.
+- `ContextReconciliationProvider` for static-context changes.
+- `ShutdownProvider` for resource cleanup.
+- `ProviderEventSource` for provider lifecycle events.
+- `DomainScopedProvider` when one provider instance supports one domain.
+- `TrackingProvider` for non-blocking tracking.
+
+An initializable or reconciling provider must also implement
+`ProviderEventSource`. It must emit the terminal lifecycle event before its
+method terminates.
+
+## Scope
+
+This package does not include an HTTP transport, an OFREP provider, a vendor
+provider, persistent storage, or Flutter APIs.
+
+## Validate the package archive
+
+The repository root uses `.pubignore` to keep client source out of the server
+package. Pub also applies that parent rule to nested publication commands. Run
+the repository staging command to validate the client archive outside the
+parent package:
+
+```text
+dart tool/stage_client_package.dart --dry-run
+```

--- a/packages/openfeature_dart_client_sdk/README.md
+++ b/packages/openfeature_dart_client_sdk/README.md
@@ -5,9 +5,9 @@ applications. It uses the static-context paradigm. It has no Flutter or
 `dart:io` dependency.
 
 The package is in beta. The first beta defines the public client and provider
-contracts. It provides synchronous typed evaluation, hooks, ordered context
-changes, and an in-memory provider. Later beta changes will complete event
-handlers and the remaining conformance work before the first stable release.
+contracts. It provides synchronous typed evaluation, event handlers, hooks,
+ordered context changes, and an in-memory provider. Later beta changes will
+complete the remaining conformance work before the first stable release.
 
 ## Use the client
 

--- a/packages/openfeature_dart_client_sdk/analysis_options.yaml
+++ b/packages/openfeature_dart_client_sdk/analysis_options.yaml
@@ -1,0 +1,9 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    avoid_dynamic_calls: true
+    directives_ordering: true
+    prefer_final_locals: true
+    sort_constructors_first: true
+    sort_unnamed_constructors_first: true

--- a/packages/openfeature_dart_client_sdk/lib/openfeature_dart_client_sdk.dart
+++ b/packages/openfeature_dart_client_sdk/lib/openfeature_dart_client_sdk.dart
@@ -1,0 +1,12 @@
+/// Pure Dart OpenFeature client SDK for the static-context paradigm.
+library;
+
+export 'src/api.dart' show OpenFeatureAPI, OpenFeatureClient;
+export 'src/details.dart';
+export 'src/error.dart';
+export 'src/evaluation_context.dart';
+export 'src/events.dart';
+export 'src/hooks.dart';
+export 'src/in_memory_provider.dart';
+export 'src/metadata.dart';
+export 'src/provider.dart';

--- a/packages/openfeature_dart_client_sdk/lib/openfeature_dart_client_sdk.dart
+++ b/packages/openfeature_dart_client_sdk/lib/openfeature_dart_client_sdk.dart
@@ -1,7 +1,8 @@
 /// Pure Dart OpenFeature client SDK for the static-context paradigm.
 library;
 
-export 'src/api.dart' show OpenFeatureAPI, OpenFeatureClient;
+export 'src/api.dart'
+    show OpenFeatureAPI, OpenFeatureClient, ProviderEventSubscription;
 export 'src/details.dart';
 export 'src/error.dart';
 export 'src/evaluation_context.dart';

--- a/packages/openfeature_dart_client_sdk/lib/openfeature_dart_client_sdk_experimental.dart
+++ b/packages/openfeature_dart_client_sdk/lib/openfeature_dart_client_sdk_experimental.dart
@@ -1,10 +1,5 @@
 /// Experimental OpenFeature Dart client APIs.
 library;
 
-import 'openfeature_dart_client_sdk.dart';
-
 export 'openfeature_dart_client_sdk.dart';
-
-/// Creates an API instance isolated from the process-wide singleton.
-OpenFeatureAPI createIsolatedOpenFeatureAPI() =>
-    OpenFeatureAPI.createIsolated();
+export 'src/api.dart' show createIsolatedOpenFeatureAPI;

--- a/packages/openfeature_dart_client_sdk/lib/openfeature_dart_client_sdk_experimental.dart
+++ b/packages/openfeature_dart_client_sdk/lib/openfeature_dart_client_sdk_experimental.dart
@@ -1,0 +1,10 @@
+/// Experimental OpenFeature Dart client APIs.
+library;
+
+import 'openfeature_dart_client_sdk.dart';
+
+export 'openfeature_dart_client_sdk.dart';
+
+/// Creates an API instance isolated from the process-wide singleton.
+OpenFeatureAPI createIsolatedOpenFeatureAPI() =>
+    OpenFeatureAPI.createIsolated();

--- a/packages/openfeature_dart_client_sdk/lib/src/api.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/api.dart
@@ -31,12 +31,28 @@ final class OpenFeatureAPI {
   final Map<String, EvaluationContext> _domainContexts =
       <String, EvaluationContext>{};
   final List<Hook> _hooks = <Hook>[];
+  final List<_EventHandlerRecord> _eventHandlers = <_EventHandlerRecord>[];
   final Map<FeatureProvider, _ProviderRecord> _providerRecords =
       HashMap<FeatureProvider, _ProviderRecord>.identity();
   Future<void> _mutationQueue = Future<void>.value();
 
   /// Adds API hooks without removing existing hooks.
   void addHooks(Iterable<Hook> hooks) => _hooks.addAll(hooks);
+
+  /// Adds an API-wide handler for [eventType].
+  ///
+  /// The handler remains registered across provider changes.
+  ProviderEventSubscription addHandler(
+    ProviderEventType eventType,
+    ProviderEventHandler handler,
+  ) {
+    return _addHandler(eventType, handler, domain: null, apiWide: true);
+  }
+
+  /// Removes a previously registered API or client event handler.
+  void removeHandler(ProviderEventSubscription subscription) {
+    subscription.cancel();
+  }
 
   /// Gets a client bound to [domain], or to the default provider when omitted.
   OpenFeatureClient getClient([String? domain]) {
@@ -163,6 +179,10 @@ final class OpenFeatureAPI {
     _domainContexts.clear();
     _globalContext = EvaluationContext.empty;
     _hooks.clear();
+    for (final handler in _eventHandlers) {
+      handler.subscription._deactivate();
+    }
+    _eventHandlers.clear();
 
     try {
       await Future.wait(
@@ -214,7 +234,10 @@ final class OpenFeatureAPI {
     Object? initializationError;
     StackTrace? initializationStackTrace;
     if (record == null) {
-      record = _ProviderRecord(initialDomain: domain);
+      record = _ProviderRecord(
+        initialDomain: domain,
+        metadata: provider.metadata,
+      );
       _providerRecords[provider] = record;
       try {
         await _initialize(provider, record, domain);
@@ -236,6 +259,10 @@ final class OpenFeatureAPI {
       _domainProviders[domain] = provider;
     }
     record.bindingCount++;
+    for (final event in record.pendingBindingEvents) {
+      _dispatchEvent(provider, record, event);
+    }
+    record.pendingBindingEvents.clear();
 
     if (!identical(current, _noOpProvider)) {
       await _releaseProvider(current);
@@ -267,10 +294,7 @@ final class OpenFeatureAPI {
   }
 
   Future<void> _enqueueMutation(Future<void> Function() operation) {
-    final result = _mutationQueue.then(
-      (_) => operation(),
-      onError: (Object _, StackTrace _) => operation(),
-    );
+    final result = _mutationQueue.then((_) => operation());
     _mutationQueue = result.catchError((Object _) {});
     return result;
   }
@@ -282,11 +306,15 @@ final class OpenFeatureAPI {
   ) async {
     if (provider is ProviderEventSource) {
       record.eventSubscription = (provider as ProviderEventSource).events
-          .listen((event) => _processEvent(record, event));
+          .listen((event) => _processEvent(provider, record, event));
     }
 
     if (provider is! InitializableProvider) {
-      record.status = ProviderStatus.ready;
+      _processEvent(
+        provider,
+        record,
+        ProviderEvent(type: ProviderEventType.ready),
+      );
       return;
     }
     if (provider is! ProviderEventSource) {
@@ -355,7 +383,11 @@ final class OpenFeatureAPI {
     }
   }
 
-  void _processEvent(_ProviderRecord record, ProviderEvent event) {
+  void _processEvent(
+    FeatureProvider provider,
+    _ProviderRecord record,
+    ProviderEvent event,
+  ) {
     switch (event.type) {
       case ProviderEventType.ready:
       case ProviderEventType.contextChanged:
@@ -376,6 +408,12 @@ final class OpenFeatureAPI {
         break;
     }
 
+    if (record.bindingCount == 0) {
+      record.pendingBindingEvents.add(event);
+    } else {
+      _dispatchEvent(provider, record, event);
+    }
+
     if (event.type == ProviderEventType.ready ||
         event.type == ProviderEventType.contextChanged ||
         event.type == ProviderEventType.error) {
@@ -383,6 +421,120 @@ final class OpenFeatureAPI {
       if (terminalEvent != null && !terminalEvent.isCompleted) {
         terminalEvent.complete(record.status);
       }
+    }
+  }
+
+  ProviderEventSubscription _addHandler(
+    ProviderEventType eventType,
+    ProviderEventHandler handler, {
+    required String? domain,
+    required bool apiWide,
+  }) {
+    late final _EventHandlerRecord record;
+    late final ProviderEventSubscription subscription;
+    subscription = ProviderEventSubscription._(() {
+      _eventHandlers.remove(record);
+    });
+    record = _EventHandlerRecord(
+      eventType: eventType,
+      handler: handler,
+      domain: domain,
+      apiWide: apiWide,
+      subscription: subscription,
+    );
+    _eventHandlers.add(record);
+    _dispatchCurrentState(record);
+    return subscription;
+  }
+
+  void _dispatchCurrentState(_EventHandlerRecord handlerRecord) {
+    if (handlerRecord.apiWide) {
+      for (final entry in _providerRecords.entries) {
+        if (entry.value.bindingCount > 0) {
+          _dispatchCurrentStateForProvider(
+            handlerRecord,
+            entry.key,
+            entry.value,
+          );
+        }
+      }
+      return;
+    }
+
+    final provider = _providerForDomain(handlerRecord.domain);
+    final providerRecord = _providerRecords[provider];
+    if (providerRecord != null) {
+      _dispatchCurrentStateForProvider(handlerRecord, provider, providerRecord);
+    }
+  }
+
+  void _dispatchCurrentStateForProvider(
+    _EventHandlerRecord handlerRecord,
+    FeatureProvider provider,
+    _ProviderRecord providerRecord,
+  ) {
+    final eventType = switch (providerRecord.status) {
+      ProviderStatus.ready => ProviderEventType.ready,
+      ProviderStatus.reconciling => ProviderEventType.reconciling,
+      ProviderStatus.stale => ProviderEventType.stale,
+      ProviderStatus.error || ProviderStatus.fatal => ProviderEventType.error,
+      ProviderStatus.notReady => null,
+    };
+    if (eventType != handlerRecord.eventType) {
+      return;
+    }
+    _invokeHandler(
+      handlerRecord,
+      providerRecord,
+      ProviderEvent(
+        type: eventType!,
+        errorCode: providerRecord.status == ProviderStatus.fatal
+            ? ErrorCode.providerFatal
+            : null,
+      ),
+    );
+  }
+
+  void _dispatchEvent(
+    FeatureProvider provider,
+    _ProviderRecord providerRecord,
+    ProviderEvent event,
+  ) {
+    for (final handlerRecord in _eventHandlers.toList(growable: false)) {
+      if (!handlerRecord.subscription.isActive ||
+          handlerRecord.eventType != event.type) {
+        continue;
+      }
+      final isAssociated =
+          handlerRecord.apiWide ||
+          identical(_providerForDomain(handlerRecord.domain), provider);
+      if (isAssociated) {
+        _invokeHandler(handlerRecord, providerRecord, event);
+      }
+    }
+  }
+
+  void _invokeHandler(
+    _EventHandlerRecord handlerRecord,
+    _ProviderRecord providerRecord,
+    ProviderEvent event,
+  ) {
+    try {
+      handlerRecord.handler(
+        ProviderEventDetails(
+          type: event.type,
+          providerMetadata: providerRecord.metadata,
+          domain: handlerRecord.apiWide
+              ? providerRecord.initialDomain
+              : handlerRecord.domain,
+          flagsChanged: event.flagsChanged,
+          message: event.message,
+          errorCode: event.errorCode,
+          metadata: event.metadata,
+        ),
+      );
+    } on Object {
+      // A failing event handler must not block lifecycle or other handlers.
     }
   }
 
@@ -423,6 +575,26 @@ final class OpenFeatureClient {
 
   /// Adds client hooks without removing existing hooks.
   void addHooks(Iterable<Hook> hooks) => _hooks.addAll(hooks);
+
+  /// Adds a handler for events associated with this client.
+  ///
+  /// The handler remains registered across provider changes.
+  ProviderEventSubscription addHandler(
+    ProviderEventType eventType,
+    ProviderEventHandler handler,
+  ) {
+    return _api._addHandler(
+      eventType,
+      handler,
+      domain: metadata.domain,
+      apiWide: false,
+    );
+  }
+
+  /// Removes a previously registered client event handler.
+  void removeHandler(ProviderEventSubscription subscription) {
+    subscription.cancel();
+  }
 
   bool getBooleanValue(
     String flagKey,
@@ -654,12 +826,51 @@ final class OpenFeatureClient {
   }
 }
 
+/// Registration returned by API and client event-handler methods.
+final class ProviderEventSubscription {
+  ProviderEventSubscription._(this._cancelHandler);
+
+  final void Function() _cancelHandler;
+  bool _isActive = true;
+
+  bool get isActive => _isActive;
+
+  /// Stops future event delivery. Repeated calls have no effect.
+  void cancel() {
+    if (!_isActive) {
+      return;
+    }
+    _isActive = false;
+    _cancelHandler();
+  }
+
+  void _deactivate() => _isActive = false;
+}
+
+final class _EventHandlerRecord {
+  const _EventHandlerRecord({
+    required this.eventType,
+    required this.handler,
+    required this.domain,
+    required this.apiWide,
+    required this.subscription,
+  });
+
+  final ProviderEventType eventType;
+  final ProviderEventHandler handler;
+  final String? domain;
+  final bool apiWide;
+  final ProviderEventSubscription subscription;
+}
+
 final class _ProviderRecord {
-  _ProviderRecord({required this.initialDomain});
+  _ProviderRecord({required this.initialDomain, required this.metadata});
 
   final String? initialDomain;
+  final ProviderMetadata metadata;
   ProviderStatus status = ProviderStatus.notReady;
   int bindingCount = 0;
   StreamSubscription<ProviderEvent>? eventSubscription;
   Completer<ProviderStatus>? terminalEvent;
+  final List<ProviderEvent> pendingBindingEvents = <ProviderEvent>[];
 }

--- a/packages/openfeature_dart_client_sdk/lib/src/api.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/api.dart
@@ -10,14 +10,14 @@ import 'metadata.dart';
 import 'no_op_provider.dart';
 import 'provider.dart';
 
+/// Creates an API instance isolated from the process-wide singleton.
+///
+/// This function is exported only from the experimental library.
+OpenFeatureAPI createIsolatedOpenFeatureAPI() => OpenFeatureAPI._();
+
 /// The static-context OpenFeature API.
 final class OpenFeatureAPI {
   OpenFeatureAPI._();
-
-  /// Creates an isolated API instance.
-  ///
-  /// This API is experimental. Prefer [instance] for application code.
-  factory OpenFeatureAPI.createIsolated() => OpenFeatureAPI._();
 
   /// The process-wide default API instance.
   static final OpenFeatureAPI instance = OpenFeatureAPI._();
@@ -187,10 +187,7 @@ final class OpenFeatureAPI {
     try {
       await Future.wait(
         records.map((entry) async {
-          await entry.value.eventSubscription?.cancel();
-          if (entry.key is ShutdownProvider) {
-            await (entry.key as ShutdownProvider).shutdown();
-          }
+          await _disposeProvider(entry.key, entry.value);
         }),
       );
     } finally {
@@ -547,14 +544,36 @@ final class OpenFeatureAPI {
     if (record.bindingCount > 0) {
       return;
     }
-    await record.eventSubscription?.cancel();
+    await _disposeProvider(provider, record);
+  }
+
+  Future<void> _disposeProvider(
+    FeatureProvider provider,
+    _ProviderRecord record,
+  ) async {
+    Object? cleanupError;
+    StackTrace? cleanupStackTrace;
+    try {
+      await record.eventSubscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      cleanupError = error;
+      cleanupStackTrace = stackTrace;
+    }
+
     try {
       if (provider is ShutdownProvider) {
         await (provider as ShutdownProvider).shutdown();
       }
+    } on Object catch (error, stackTrace) {
+      cleanupError ??= error;
+      cleanupStackTrace ??= stackTrace;
     } finally {
       record.status = ProviderStatus.notReady;
       _providerRecords.remove(provider);
+    }
+
+    if (cleanupError != null) {
+      Error.throwWithStackTrace(cleanupError, cleanupStackTrace!);
     }
   }
 }

--- a/packages/openfeature_dart_client_sdk/lib/src/api.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/api.dart
@@ -1,0 +1,665 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'details.dart';
+import 'error.dart';
+import 'evaluation_context.dart';
+import 'events.dart';
+import 'hooks.dart';
+import 'metadata.dart';
+import 'no_op_provider.dart';
+import 'provider.dart';
+
+/// The static-context OpenFeature API.
+final class OpenFeatureAPI {
+  OpenFeatureAPI._();
+
+  /// Creates an isolated API instance.
+  ///
+  /// This API is experimental. Prefer [instance] for application code.
+  factory OpenFeatureAPI.createIsolated() => OpenFeatureAPI._();
+
+  /// The process-wide default API instance.
+  static final OpenFeatureAPI instance = OpenFeatureAPI._();
+
+  static const FeatureProvider _noOpProvider = NoOpProvider();
+
+  FeatureProvider _defaultProvider = _noOpProvider;
+  final Map<String, FeatureProvider> _domainProviders =
+      <String, FeatureProvider>{};
+  EvaluationContext _globalContext = EvaluationContext.empty;
+  final Map<String, EvaluationContext> _domainContexts =
+      <String, EvaluationContext>{};
+  final List<Hook> _hooks = <Hook>[];
+  final Map<FeatureProvider, _ProviderRecord> _providerRecords =
+      HashMap<FeatureProvider, _ProviderRecord>.identity();
+  Future<void> _mutationQueue = Future<void>.value();
+
+  /// Adds API hooks without removing existing hooks.
+  void addHooks(Iterable<Hook> hooks) => _hooks.addAll(hooks);
+
+  /// Gets a client bound to [domain], or to the default provider when omitted.
+  OpenFeatureClient getClient([String? domain]) {
+    return OpenFeatureClient._(this, ClientMetadata(domain: domain));
+  }
+
+  /// Gets metadata for the provider selected by [domain].
+  ProviderMetadata getProviderMetadata([String? domain]) {
+    return _providerForDomain(domain).metadata;
+  }
+
+  /// Starts registration of the default provider.
+  void setProvider(FeatureProvider provider) {
+    unawaited(setProviderAndWait(provider).catchError((Object _) {}));
+  }
+
+  /// Registers the default provider after its initialization terminates.
+  Future<void> setProviderAndWait(FeatureProvider provider) {
+    return _enqueueMutation(() => _setProvider(provider, domain: null));
+  }
+
+  /// Starts registration of [provider] for [domain].
+  void setProviderForDomain(String domain, FeatureProvider provider) {
+    unawaited(
+      setProviderForDomainAndWait(domain, provider).catchError((Object _) {}),
+    );
+  }
+
+  /// Registers [provider] for [domain] after initialization terminates.
+  Future<void> setProviderForDomainAndWait(
+    String domain,
+    FeatureProvider provider,
+  ) {
+    return _enqueueMutation(() => _setProvider(provider, domain: domain));
+  }
+
+  /// Starts a global context change.
+  void setEvaluationContext(EvaluationContext context) {
+    unawaited(setEvaluationContextAndWait(context).catchError((Object _) {}));
+  }
+
+  /// Sets the global static evaluation context.
+  Future<void> setEvaluationContextAndWait(EvaluationContext context) {
+    return _enqueueMutation(() => _setGlobalContext(context));
+  }
+
+  Future<void> _setGlobalContext(EvaluationContext context) async {
+    final previousContext = _globalContext;
+    final providers = HashSet<FeatureProvider>.identity()
+      ..add(_defaultProvider)
+      ..addAll(
+        _domainProviders.entries
+            .where((entry) => !_domainContexts.containsKey(entry.key))
+            .map((entry) => entry.value),
+      )
+      ..remove(_noOpProvider);
+
+    await Future.wait(
+      providers.map(
+        (provider) => _reconcile(provider, previousContext, context),
+      ),
+    );
+    _globalContext = context;
+  }
+
+  /// Starts a context change for [domain].
+  void setEvaluationContextForDomain(String domain, EvaluationContext context) {
+    unawaited(
+      setEvaluationContextForDomainAndWait(
+        domain,
+        context,
+      ).catchError((Object _) {}),
+    );
+  }
+
+  /// Sets the static evaluation context for [domain].
+  Future<void> setEvaluationContextForDomainAndWait(
+    String domain,
+    EvaluationContext context,
+  ) {
+    return _enqueueMutation(() => _setDomainContext(domain, context));
+  }
+
+  Future<void> _setDomainContext(
+    String domain,
+    EvaluationContext context,
+  ) async {
+    final previousContext = _contextForDomain(domain);
+    final provider = _domainProviders[domain];
+    if (provider != null) {
+      await _reconcile(provider, previousContext, context);
+    }
+    _domainContexts[domain] = context;
+  }
+
+  /// Clears a domain context and restores global-context fallback.
+  Future<void> clearEvaluationContextForDomainAndWait(String domain) {
+    return _enqueueMutation(() => _clearDomainContext(domain));
+  }
+
+  Future<void> _clearDomainContext(String domain) async {
+    final previousContext = _contextForDomain(domain);
+    final provider = _domainProviders[domain];
+    if (provider != null && _domainContexts.containsKey(domain)) {
+      await _reconcile(provider, previousContext, _globalContext);
+    }
+    _domainContexts.remove(domain);
+  }
+
+  /// Starts clearing a domain context.
+  void clearEvaluationContextForDomain(String domain) {
+    unawaited(
+      clearEvaluationContextForDomainAndWait(domain).catchError((Object _) {}),
+    );
+  }
+
+  /// Shuts down all active providers and resets API state.
+  Future<void> shutdown() => _enqueueMutation(_shutdown);
+
+  Future<void> _shutdown() async {
+    final records = _providerRecords.entries.toList(growable: false);
+    _defaultProvider = _noOpProvider;
+    _domainProviders.clear();
+    _domainContexts.clear();
+    _globalContext = EvaluationContext.empty;
+    _hooks.clear();
+
+    try {
+      await Future.wait(
+        records.map((entry) async {
+          await entry.value.eventSubscription?.cancel();
+          if (entry.key is ShutdownProvider) {
+            await (entry.key as ShutdownProvider).shutdown();
+          }
+        }),
+      );
+    } finally {
+      _providerRecords.clear();
+    }
+  }
+
+  FeatureProvider _providerForDomain(String? domain) {
+    if (domain == null) {
+      return _defaultProvider;
+    }
+    return _domainProviders[domain] ?? _defaultProvider;
+  }
+
+  EvaluationContext _contextForDomain(String? domain) {
+    if (domain == null) {
+      return _globalContext;
+    }
+    return _domainContexts[domain] ?? _globalContext;
+  }
+
+  ProviderStatus _statusForDomain(String? domain) {
+    final provider = _providerForDomain(domain);
+    if (identical(provider, _noOpProvider)) {
+      return ProviderStatus.notReady;
+    }
+    return _providerRecords[provider]?.status ?? ProviderStatus.notReady;
+  }
+
+  Future<void> _setProvider(
+    FeatureProvider provider, {
+    required String? domain,
+  }) async {
+    final current = _providerForExactBinding(domain);
+    if (identical(current, provider)) {
+      return;
+    }
+    _validateDomainScope(provider, domain);
+
+    var record = _providerRecords[provider];
+    Object? initializationError;
+    StackTrace? initializationStackTrace;
+    if (record == null) {
+      record = _ProviderRecord(initialDomain: domain);
+      _providerRecords[provider] = record;
+      try {
+        await _initialize(provider, record, domain);
+      } on Object catch (error, stackTrace) {
+        if (record.status != ProviderStatus.error &&
+            record.status != ProviderStatus.fatal) {
+          await record.eventSubscription?.cancel();
+          _providerRecords.remove(provider);
+          rethrow;
+        }
+        initializationError = error;
+        initializationStackTrace = stackTrace;
+      }
+    }
+
+    if (domain == null) {
+      _defaultProvider = provider;
+    } else {
+      _domainProviders[domain] = provider;
+    }
+    record.bindingCount++;
+
+    if (!identical(current, _noOpProvider)) {
+      await _releaseProvider(current);
+    }
+    if (initializationError != null) {
+      Error.throwWithStackTrace(initializationError, initializationStackTrace!);
+    }
+  }
+
+  FeatureProvider _providerForExactBinding(String? domain) {
+    if (domain == null) {
+      return _defaultProvider;
+    }
+    return _domainProviders[domain] ?? _noOpProvider;
+  }
+
+  void _validateDomainScope(FeatureProvider provider, String? domain) {
+    if (provider is! DomainScopedProvider) {
+      return;
+    }
+    final record = _providerRecords[provider];
+    if (record != null &&
+        record.bindingCount > 0 &&
+        record.initialDomain != domain) {
+      throw const OpenFeatureException(
+        'A domain-scoped provider can be bound to only one domain.',
+      );
+    }
+  }
+
+  Future<void> _enqueueMutation(Future<void> Function() operation) {
+    final result = _mutationQueue.then(
+      (_) => operation(),
+      onError: (Object _, StackTrace _) => operation(),
+    );
+    _mutationQueue = result.catchError((Object _) {});
+    return result;
+  }
+
+  Future<void> _initialize(
+    FeatureProvider provider,
+    _ProviderRecord record,
+    String? domain,
+  ) async {
+    if (provider is ProviderEventSource) {
+      record.eventSubscription = (provider as ProviderEventSource).events
+          .listen((event) => _processEvent(record, event));
+    }
+
+    if (provider is! InitializableProvider) {
+      record.status = ProviderStatus.ready;
+      return;
+    }
+    if (provider is! ProviderEventSource) {
+      throw const OpenFeatureException(
+        'A provider with initialize() must expose provider events.',
+      );
+    }
+
+    final terminalEvent = Completer<ProviderStatus>();
+    record.terminalEvent = terminalEvent;
+    try {
+      await (provider as InitializableProvider).initialize(
+        _contextForDomain(domain),
+        domain: domain,
+      );
+      final status = await terminalEvent.future;
+      if (status == ProviderStatus.error || status == ProviderStatus.fatal) {
+        throw OpenFeatureException(
+          'Provider initialization ended with status ${status.name}.',
+          errorCode: status == ProviderStatus.fatal
+              ? ErrorCode.providerFatal
+              : ErrorCode.general,
+        );
+      }
+    } finally {
+      record.terminalEvent = null;
+    }
+  }
+
+  Future<void> _reconcile(
+    FeatureProvider provider,
+    EvaluationContext previousContext,
+    EvaluationContext newContext,
+  ) async {
+    if (provider is! ContextReconciliationProvider) {
+      return;
+    }
+    if (provider is! ProviderEventSource) {
+      throw const OpenFeatureException(
+        'A provider with onContextChanged() must expose provider events.',
+      );
+    }
+
+    final record = _providerRecords[provider];
+    if (record == null) {
+      return;
+    }
+    final terminalEvent = Completer<ProviderStatus>();
+    record.terminalEvent = terminalEvent;
+    try {
+      await (provider as ContextReconciliationProvider).onContextChanged(
+        previousContext,
+        newContext,
+      );
+      final status = await terminalEvent.future;
+      if (status == ProviderStatus.error || status == ProviderStatus.fatal) {
+        throw OpenFeatureException(
+          'Provider reconciliation ended with status ${status.name}.',
+          errorCode: status == ProviderStatus.fatal
+              ? ErrorCode.providerFatal
+              : ErrorCode.general,
+        );
+      }
+    } finally {
+      record.terminalEvent = null;
+    }
+  }
+
+  void _processEvent(_ProviderRecord record, ProviderEvent event) {
+    switch (event.type) {
+      case ProviderEventType.ready:
+      case ProviderEventType.contextChanged:
+        record.status = ProviderStatus.ready;
+        break;
+      case ProviderEventType.error:
+        record.status = event.errorCode == ErrorCode.providerFatal
+            ? ProviderStatus.fatal
+            : ProviderStatus.error;
+        break;
+      case ProviderEventType.stale:
+        record.status = ProviderStatus.stale;
+        break;
+      case ProviderEventType.reconciling:
+        record.status = ProviderStatus.reconciling;
+        break;
+      case ProviderEventType.configurationChanged:
+        break;
+    }
+
+    if (event.type == ProviderEventType.ready ||
+        event.type == ProviderEventType.contextChanged ||
+        event.type == ProviderEventType.error) {
+      final terminalEvent = record.terminalEvent;
+      if (terminalEvent != null && !terminalEvent.isCompleted) {
+        terminalEvent.complete(record.status);
+      }
+    }
+  }
+
+  Future<void> _releaseProvider(FeatureProvider provider) async {
+    final record = _providerRecords[provider];
+    if (record == null) {
+      return;
+    }
+    record.bindingCount--;
+    if (record.bindingCount > 0) {
+      return;
+    }
+    await record.eventSubscription?.cancel();
+    try {
+      if (provider is ShutdownProvider) {
+        await (provider as ShutdownProvider).shutdown();
+      }
+    } finally {
+      record.status = ProviderStatus.notReady;
+      _providerRecords.remove(provider);
+    }
+  }
+}
+
+/// A client bound to one OpenFeature domain.
+final class OpenFeatureClient {
+  OpenFeatureClient._(this._api, this.metadata);
+
+  final OpenFeatureAPI _api;
+  final List<Hook> _hooks = <Hook>[];
+
+  final ClientMetadata metadata;
+
+  ProviderMetadata get providerMetadata =>
+      _api.getProviderMetadata(metadata.domain);
+
+  ProviderStatus get providerStatus => _api._statusForDomain(metadata.domain);
+
+  /// Adds client hooks without removing existing hooks.
+  void addHooks(Iterable<Hook> hooks) => _hooks.addAll(hooks);
+
+  bool getBooleanValue(
+    String flagKey,
+    bool defaultValue, {
+    EvaluationOptions? options,
+  }) => getBooleanDetails(flagKey, defaultValue, options: options).value;
+
+  FlagEvaluationDetails<bool> getBooleanDetails(
+    String flagKey,
+    bool defaultValue, {
+    EvaluationOptions? options,
+  }) {
+    return _evaluate(
+      flagKey,
+      defaultValue,
+      FlagValueType.boolean,
+      (provider, context) =>
+          provider.resolveBooleanValue(flagKey, defaultValue, context),
+      options: options,
+    );
+  }
+
+  String getStringValue(
+    String flagKey,
+    String defaultValue, {
+    EvaluationOptions? options,
+  }) => getStringDetails(flagKey, defaultValue, options: options).value;
+
+  FlagEvaluationDetails<String> getStringDetails(
+    String flagKey,
+    String defaultValue, {
+    EvaluationOptions? options,
+  }) {
+    return _evaluate(
+      flagKey,
+      defaultValue,
+      FlagValueType.string,
+      (provider, context) =>
+          provider.resolveStringValue(flagKey, defaultValue, context),
+      options: options,
+    );
+  }
+
+  int getIntegerValue(
+    String flagKey,
+    int defaultValue, {
+    EvaluationOptions? options,
+  }) => getIntegerDetails(flagKey, defaultValue, options: options).value;
+
+  FlagEvaluationDetails<int> getIntegerDetails(
+    String flagKey,
+    int defaultValue, {
+    EvaluationOptions? options,
+  }) {
+    return _evaluate(
+      flagKey,
+      defaultValue,
+      FlagValueType.integer,
+      (provider, context) =>
+          provider.resolveIntegerValue(flagKey, defaultValue, context),
+      options: options,
+    );
+  }
+
+  double getDoubleValue(
+    String flagKey,
+    double defaultValue, {
+    EvaluationOptions? options,
+  }) => getDoubleDetails(flagKey, defaultValue, options: options).value;
+
+  FlagEvaluationDetails<double> getDoubleDetails(
+    String flagKey,
+    double defaultValue, {
+    EvaluationOptions? options,
+  }) {
+    return _evaluate(
+      flagKey,
+      defaultValue,
+      FlagValueType.double,
+      (provider, context) =>
+          provider.resolveDoubleValue(flagKey, defaultValue, context),
+      options: options,
+    );
+  }
+
+  Map<String, Object?> getStructureValue(
+    String flagKey,
+    Map<String, Object?> defaultValue, {
+    EvaluationOptions? options,
+  }) => getStructureDetails(flagKey, defaultValue, options: options).value;
+
+  FlagEvaluationDetails<Map<String, Object?>> getStructureDetails(
+    String flagKey,
+    Map<String, Object?> defaultValue, {
+    EvaluationOptions? options,
+  }) {
+    return _evaluate(
+      flagKey,
+      defaultValue,
+      FlagValueType.structure,
+      (provider, context) =>
+          provider.resolveStructureValue(flagKey, defaultValue, context),
+      options: options,
+    );
+  }
+
+  /// Sends a non-blocking tracking call when the provider supports tracking.
+  void track(String trackingEventName, {TrackingEventDetails? details}) {
+    final provider = _api._providerForDomain(metadata.domain);
+    if (provider is TrackingProvider) {
+      try {
+        (provider as TrackingProvider).track(
+          trackingEventName,
+          _api._contextForDomain(metadata.domain),
+          details: details,
+        );
+      } on Object {
+        // Tracking support must not cause abnormal application execution.
+      }
+    }
+  }
+
+  FlagEvaluationDetails<T> _evaluate<T extends Object>(
+    String flagKey,
+    T defaultValue,
+    FlagValueType flagValueType,
+    ResolutionDetails<T> Function(
+      FeatureProvider provider,
+      EvaluationContext context,
+    )
+    resolve, {
+    EvaluationOptions? options,
+  }) {
+    final provider = _api._providerForDomain(metadata.domain);
+    final evaluationContext = _api._contextForDomain(metadata.domain);
+    final hints = options?.hookHints ?? HookHints();
+    late final List<Hook> hooks;
+    late final ProviderMetadata providerMetadata;
+    try {
+      providerMetadata = provider.metadata;
+      hooks = <Hook>[
+        ..._api._hooks,
+        ..._hooks,
+        ...?options?.hooks,
+        if (provider is ProviderHooks) ...(provider as ProviderHooks).hooks,
+      ];
+    } on Object catch (error) {
+      return _errorDetails(flagKey, defaultValue, error);
+    }
+
+    final hookContexts = hooks
+        .map(
+          (_) => HookContext(
+            flagKey: flagKey,
+            defaultValue: defaultValue,
+            flagValueType: flagValueType,
+            clientMetadata: metadata,
+            providerMetadata: providerMetadata,
+            evaluationContext: evaluationContext,
+          ),
+        )
+        .toList(growable: false);
+
+    FlagEvaluationDetails<T>? details;
+    Object? evaluationError;
+    try {
+      for (var index = 0; index < hooks.length; index++) {
+        hooks[index].before(hookContexts[index], hints);
+      }
+      final resolution = resolve(provider, evaluationContext);
+      details = FlagEvaluationDetails<T>(
+        flagKey: flagKey,
+        value: resolution.errorCode == null ? resolution.value : defaultValue,
+        errorCode: resolution.errorCode,
+        errorMessage: resolution.errorMessage,
+        reason: resolution.reason,
+        variant: resolution.variant,
+        flagMetadata: resolution.flagMetadata,
+      );
+      if (resolution.errorCode != null) {
+        evaluationError = OpenFeatureException(
+          resolution.errorMessage ?? 'Provider resolution failed.',
+          errorCode: resolution.errorCode!,
+        );
+      } else {
+        for (var index = hooks.length - 1; index >= 0; index--) {
+          hooks[index].after(hookContexts[index], details, hints);
+        }
+      }
+    } on Object catch (error) {
+      evaluationError = error;
+      details = _errorDetails(flagKey, defaultValue, error);
+    }
+
+    if (evaluationError != null) {
+      for (var index = hooks.length - 1; index >= 0; index--) {
+        try {
+          hooks[index].error(hookContexts[index], evaluationError, hints);
+        } on Object {
+          // Error hooks must not prevent remaining hooks or evaluation.
+        }
+      }
+    }
+
+    for (var index = hooks.length - 1; index >= 0; index--) {
+      try {
+        hooks[index].finallyAfter(hookContexts[index], details, hints);
+      } on Object {
+        // Finally hooks must not prevent remaining hooks or evaluation.
+      }
+    }
+    return details;
+  }
+
+  FlagEvaluationDetails<T> _errorDetails<T extends Object>(
+    String flagKey,
+    T defaultValue,
+    Object error,
+  ) {
+    return FlagEvaluationDetails<T>(
+      flagKey: flagKey,
+      value: defaultValue,
+      errorCode: error is OpenFeatureException
+          ? error.errorCode
+          : ErrorCode.general,
+      errorMessage: error.toString(),
+      reason: 'ERROR',
+    );
+  }
+}
+
+final class _ProviderRecord {
+  _ProviderRecord({required this.initialDomain});
+
+  final String? initialDomain;
+  ProviderStatus status = ProviderStatus.notReady;
+  int bindingCount = 0;
+  StreamSubscription<ProviderEvent>? eventSubscription;
+  Completer<ProviderStatus>? terminalEvent;
+}

--- a/packages/openfeature_dart_client_sdk/lib/src/details.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/details.dart
@@ -1,0 +1,42 @@
+import 'error.dart';
+import 'immutable.dart';
+
+/// Details returned by a provider resolver.
+final class ResolutionDetails<T> {
+  ResolutionDetails({
+    required this.value,
+    this.errorCode,
+    this.errorMessage,
+    this.reason,
+    this.variant,
+    Map<String, Object> flagMetadata = const {},
+  }) : flagMetadata = immutableMetadata(flagMetadata, path: 'flagMetadata');
+
+  final T value;
+  final ErrorCode? errorCode;
+  final String? errorMessage;
+  final String? reason;
+  final String? variant;
+  final Map<String, Object> flagMetadata;
+}
+
+/// Details returned to an application after flag evaluation.
+final class FlagEvaluationDetails<T> {
+  FlagEvaluationDetails({
+    required this.flagKey,
+    required this.value,
+    this.errorCode,
+    this.errorMessage,
+    this.reason,
+    this.variant,
+    Map<String, Object> flagMetadata = const {},
+  }) : flagMetadata = immutableMetadata(flagMetadata, path: 'flagMetadata');
+
+  final String flagKey;
+  final T value;
+  final ErrorCode? errorCode;
+  final String? errorMessage;
+  final String? reason;
+  final String? variant;
+  final Map<String, Object> flagMetadata;
+}

--- a/packages/openfeature_dart_client_sdk/lib/src/error.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/error.dart
@@ -1,0 +1,25 @@
+/// OpenFeature error codes reported during flag resolution.
+enum ErrorCode {
+  providerNotReady,
+  flagNotFound,
+  parseError,
+  typeMismatch,
+  targetingKeyMissing,
+  invalidContext,
+  providerFatal,
+  general,
+}
+
+/// An error from client SDK configuration or provider lifecycle work.
+final class OpenFeatureException implements Exception {
+  const OpenFeatureException(
+    this.message, {
+    this.errorCode = ErrorCode.general,
+  });
+
+  final String message;
+  final ErrorCode errorCode;
+
+  @override
+  String toString() => 'OpenFeatureException: $message (${errorCode.name})';
+}

--- a/packages/openfeature_dart_client_sdk/lib/src/evaluation_context.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/evaluation_context.dart
@@ -1,0 +1,43 @@
+import 'immutable.dart';
+
+/// Immutable targeting data used by static-context flag evaluations.
+final class EvaluationContext {
+  factory EvaluationContext({
+    String? targetingKey,
+    Map<String, Object?> attributes = const {},
+  }) {
+    if (attributes.containsKey('targetingKey')) {
+      throw ArgumentError.value(
+        attributes,
+        'attributes',
+        'Use the targetingKey parameter for the targeting key',
+      );
+    }
+    return EvaluationContext._(
+      targetingKey,
+      immutableStructure(attributes, path: 'attributes'),
+    );
+  }
+
+  const EvaluationContext._(this.targetingKey, this.attributes);
+
+  /// An empty evaluation context.
+  static const empty = EvaluationContext._(null, <String, Object?>{});
+
+  /// Identifies the subject of flag evaluation.
+  final String? targetingKey;
+
+  /// Custom context fields.
+  final Map<String, Object?> attributes;
+
+  /// Returns the custom field for [key].
+  Object? getValue(String key) => attributes[key];
+
+  /// Returns all fields, including `targetingKey` when it is set.
+  Map<String, Object?> asMap() {
+    return Map<String, Object?>.unmodifiable({
+      if (targetingKey != null) 'targetingKey': targetingKey,
+      ...attributes,
+    });
+  }
+}

--- a/packages/openfeature_dart_client_sdk/lib/src/events.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/events.dart
@@ -1,0 +1,30 @@
+import 'error.dart';
+import 'immutable.dart';
+
+/// Provider lifecycle and configuration events.
+enum ProviderEventType {
+  ready,
+  error,
+  configurationChanged,
+  stale,
+  reconciling,
+  contextChanged,
+}
+
+/// Event data emitted by a feature provider.
+final class ProviderEvent {
+  ProviderEvent({
+    required this.type,
+    Iterable<String> flagsChanged = const [],
+    this.message,
+    this.errorCode,
+    Map<String, Object> metadata = const {},
+  }) : flagsChanged = List<String>.unmodifiable(flagsChanged),
+       metadata = immutableMetadata(metadata, path: 'eventMetadata');
+
+  final ProviderEventType type;
+  final List<String> flagsChanged;
+  final String? message;
+  final ErrorCode? errorCode;
+  final Map<String, Object> metadata;
+}

--- a/packages/openfeature_dart_client_sdk/lib/src/events.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/events.dart
@@ -1,5 +1,6 @@
 import 'error.dart';
 import 'immutable.dart';
+import 'metadata.dart';
 
 /// Provider lifecycle and configuration events.
 enum ProviderEventType {
@@ -28,3 +29,28 @@ final class ProviderEvent {
   final ErrorCode? errorCode;
   final Map<String, Object> metadata;
 }
+
+/// Event data delivered by the SDK to API and client handlers.
+final class ProviderEventDetails {
+  ProviderEventDetails({
+    required this.type,
+    required this.providerMetadata,
+    this.domain,
+    Iterable<String> flagsChanged = const [],
+    this.message,
+    this.errorCode,
+    Map<String, Object> metadata = const {},
+  }) : flagsChanged = List<String>.unmodifiable(flagsChanged),
+       metadata = immutableMetadata(metadata, path: 'eventMetadata');
+
+  final ProviderEventType type;
+  final ProviderMetadata providerMetadata;
+  final String? domain;
+  final List<String> flagsChanged;
+  final String? message;
+  final ErrorCode? errorCode;
+  final Map<String, Object> metadata;
+}
+
+/// Receives one provider event after the SDK updates provider status.
+typedef ProviderEventHandler = void Function(ProviderEventDetails details);

--- a/packages/openfeature_dart_client_sdk/lib/src/hooks.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/hooks.dart
@@ -1,0 +1,95 @@
+import 'details.dart';
+import 'evaluation_context.dart';
+import 'immutable.dart';
+import 'metadata.dart';
+
+/// The type expected from a typed flag evaluation.
+enum FlagValueType { boolean, string, integer, double, structure }
+
+/// Immutable hook hints supplied with one flag evaluation.
+final class HookHints {
+  HookHints([Map<String, Object?> values = const {}])
+    : values = immutableStructure(values, path: 'hookHints');
+
+  final Map<String, Object?> values;
+
+  Object? operator [](String key) => values[key];
+}
+
+/// Context available to an evaluation hook.
+final class HookContext {
+  HookContext({
+    required this.flagKey,
+    required this.defaultValue,
+    required this.flagValueType,
+    required this.clientMetadata,
+    required this.providerMetadata,
+    required this.evaluationContext,
+  });
+
+  final String flagKey;
+  final Object defaultValue;
+  final FlagValueType flagValueType;
+  final ClientMetadata clientMetadata;
+  final ProviderMetadata providerMetadata;
+  final EvaluationContext evaluationContext;
+
+  /// Mutable data shared by hook stages for this evaluation only.
+  final Map<String, Object?> hookData = <String, Object?>{};
+}
+
+/// A synchronous hook for the static-context evaluation path.
+abstract interface class Hook {
+  void before(HookContext context, HookHints hints);
+
+  void after(
+    HookContext context,
+    FlagEvaluationDetails<Object> details,
+    HookHints hints,
+  );
+
+  void error(HookContext context, Object error, HookHints hints);
+
+  void finallyAfter(
+    HookContext context,
+    FlagEvaluationDetails<Object> details,
+    HookHints hints,
+  );
+}
+
+/// Empty hook implementation for consumers that need only selected stages.
+abstract base class HookAdapter implements Hook {
+  const HookAdapter();
+
+  @override
+  void after(
+    HookContext context,
+    FlagEvaluationDetails<Object> details,
+    HookHints hints,
+  ) {}
+
+  @override
+  void before(HookContext context, HookHints hints) {}
+
+  @override
+  void error(HookContext context, Object error, HookHints hints) {}
+
+  @override
+  void finallyAfter(
+    HookContext context,
+    FlagEvaluationDetails<Object> details,
+    HookHints hints,
+  ) {}
+}
+
+/// Per-evaluation options for hooks and hook hints.
+final class EvaluationOptions {
+  EvaluationOptions({
+    Iterable<Hook> hooks = const [],
+    Map<String, Object?> hookHints = const {},
+  }) : hooks = List<Hook>.unmodifiable(hooks),
+       hookHints = HookHints(hookHints);
+
+  final List<Hook> hooks;
+  final HookHints hookHints;
+}

--- a/packages/openfeature_dart_client_sdk/lib/src/immutable.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/immutable.dart
@@ -1,0 +1,63 @@
+Object? immutableValue(Object? value, {String path = 'value'}) {
+  if (value == null ||
+      value is bool ||
+      value is String ||
+      value is num ||
+      value is DateTime) {
+    return value;
+  }
+
+  if (value is List<Object?>) {
+    return List<Object?>.unmodifiable(
+      value.indexed.map(
+        (entry) => immutableValue(entry.$2, path: '$path[${entry.$1}]'),
+      ),
+    );
+  }
+
+  if (value is Map) {
+    final result = <String, Object?>{};
+    for (final entry in value.entries) {
+      final key = entry.key;
+      if (key is! String) {
+        throw ArgumentError.value(key, path, 'Map keys must be strings');
+      }
+      result[key] = immutableValue(entry.value, path: '$path.$key');
+    }
+    return Map<String, Object?>.unmodifiable(result);
+  }
+
+  throw ArgumentError.value(
+    value,
+    path,
+    'Expected null, bool, String, num, DateTime, List, or Map',
+  );
+}
+
+Map<String, Object?> immutableStructure(
+  Map<String, Object?> value, {
+  String path = 'value',
+}) {
+  return immutableValue(value, path: path)! as Map<String, Object?>;
+}
+
+Map<String, Object> immutableMetadata(
+  Map<String, Object> value, {
+  String path = 'metadata',
+}) {
+  final result = <String, Object>{};
+  for (final entry in value.entries) {
+    final metadataValue = entry.value;
+    if (metadataValue is! bool &&
+        metadataValue is! String &&
+        metadataValue is! num) {
+      throw ArgumentError.value(
+        metadataValue,
+        '$path.${entry.key}',
+        'Metadata values must be bool, String, or num',
+      );
+    }
+    result[entry.key] = metadataValue;
+  }
+  return Map<String, Object>.unmodifiable(result);
+}

--- a/packages/openfeature_dart_client_sdk/lib/src/in_memory_provider.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/in_memory_provider.dart
@@ -101,10 +101,7 @@ final class InMemoryProvider implements FeatureProvider, ProviderEventSource {
     return Map<String, Object>.unmodifiable(
       flags.map((key, value) {
         final copy = immutableValue(value, path: 'flags.$key');
-        if (copy == null) {
-          throw ArgumentError.value(value, 'flags.$key', 'Flag cannot be null');
-        }
-        return MapEntry(key, copy);
+        return MapEntry(key, copy!);
       }),
     );
   }

--- a/packages/openfeature_dart_client_sdk/lib/src/in_memory_provider.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/in_memory_provider.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'details.dart';
+import 'error.dart';
+import 'evaluation_context.dart';
+import 'events.dart';
+import 'immutable.dart';
+import 'metadata.dart';
+import 'provider.dart';
+
+/// A provider for conformance tests and application tests.
+final class InMemoryProvider implements FeatureProvider, ProviderEventSource {
+  InMemoryProvider([Map<String, Object> flags = const {}])
+    : _flags = _copyFlags(flags);
+
+  Map<String, Object> _flags;
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  @override
+  ProviderMetadata get metadata =>
+      const ProviderMetadata(name: 'In-memory Provider');
+
+  /// Replaces the complete flag set and emits a configuration event.
+  void replaceAll(Map<String, Object> flags) {
+    final previousKeys = _flags.keys.toSet();
+    final nextFlags = _copyFlags(flags);
+    final changedKeys = <String>{...previousKeys, ...nextFlags.keys}.toList()
+      ..sort();
+    _flags = nextFlags;
+    _events.add(
+      ProviderEvent(
+        type: ProviderEventType.configurationChanged,
+        flagsChanged: changedKeys,
+      ),
+    );
+  }
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) => _resolve(flagKey, defaultValue);
+
+  @override
+  ResolutionDetails<double> resolveDoubleValue(
+    String flagKey,
+    double defaultValue,
+    EvaluationContext context,
+  ) => _resolve(flagKey, defaultValue);
+
+  @override
+  ResolutionDetails<int> resolveIntegerValue(
+    String flagKey,
+    int defaultValue,
+    EvaluationContext context,
+  ) => _resolve(flagKey, defaultValue);
+
+  @override
+  ResolutionDetails<String> resolveStringValue(
+    String flagKey,
+    String defaultValue,
+    EvaluationContext context,
+  ) => _resolve(flagKey, defaultValue);
+
+  @override
+  ResolutionDetails<Map<String, Object?>> resolveStructureValue(
+    String flagKey,
+    Map<String, Object?> defaultValue,
+    EvaluationContext context,
+  ) => _resolve(flagKey, immutableStructure(defaultValue));
+
+  ResolutionDetails<T> _resolve<T>(String flagKey, T defaultValue) {
+    if (!_flags.containsKey(flagKey)) {
+      return ResolutionDetails<T>(
+        value: defaultValue,
+        errorCode: ErrorCode.flagNotFound,
+        errorMessage: 'Flag "$flagKey" was not found.',
+        reason: 'ERROR',
+      );
+    }
+
+    final value = _flags[flagKey];
+    if (value is! T) {
+      return ResolutionDetails<T>(
+        value: defaultValue,
+        errorCode: ErrorCode.typeMismatch,
+        errorMessage: 'Flag "$flagKey" has an unexpected type.',
+        reason: 'ERROR',
+      );
+    }
+
+    return ResolutionDetails<T>(value: value, reason: 'STATIC');
+  }
+
+  static Map<String, Object> _copyFlags(Map<String, Object> flags) {
+    return Map<String, Object>.unmodifiable(
+      flags.map((key, value) {
+        final copy = immutableValue(value, path: 'flags.$key');
+        if (copy == null) {
+          throw ArgumentError.value(value, 'flags.$key', 'Flag cannot be null');
+        }
+        return MapEntry(key, copy);
+      }),
+    );
+  }
+}

--- a/packages/openfeature_dart_client_sdk/lib/src/metadata.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/metadata.dart
@@ -1,0 +1,23 @@
+import 'immutable.dart';
+
+/// Immutable client metadata.
+final class ClientMetadata {
+  const ClientMetadata({this.domain});
+
+  /// The domain used to bind this client to a provider.
+  final String? domain;
+
+  /// Alias retained for SDKs and applications that use the earlier term.
+  String? get name => domain;
+}
+
+/// Immutable provider metadata.
+final class ProviderMetadata {
+  const ProviderMetadata({required this.name});
+
+  final String name;
+}
+
+/// Creates an immutable OpenFeature flag metadata record.
+Map<String, Object> flagMetadata([Map<String, Object> values = const {}]) =>
+    immutableMetadata(values, path: 'flagMetadata');

--- a/packages/openfeature_dart_client_sdk/lib/src/no_op_provider.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/no_op_provider.dart
@@ -1,0 +1,57 @@
+import 'details.dart';
+import 'error.dart';
+import 'evaluation_context.dart';
+import 'metadata.dart';
+import 'provider.dart';
+
+final class NoOpProvider implements FeatureProvider {
+  const NoOpProvider();
+
+  @override
+  ProviderMetadata get metadata =>
+      const ProviderMetadata(name: 'No-op Provider');
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) => _details(defaultValue);
+
+  @override
+  ResolutionDetails<double> resolveDoubleValue(
+    String flagKey,
+    double defaultValue,
+    EvaluationContext context,
+  ) => _details(defaultValue);
+
+  @override
+  ResolutionDetails<int> resolveIntegerValue(
+    String flagKey,
+    int defaultValue,
+    EvaluationContext context,
+  ) => _details(defaultValue);
+
+  @override
+  ResolutionDetails<String> resolveStringValue(
+    String flagKey,
+    String defaultValue,
+    EvaluationContext context,
+  ) => _details(defaultValue);
+
+  @override
+  ResolutionDetails<Map<String, Object?>> resolveStructureValue(
+    String flagKey,
+    Map<String, Object?> defaultValue,
+    EvaluationContext context,
+  ) => _details(defaultValue);
+
+  ResolutionDetails<T> _details<T>(T defaultValue) {
+    return ResolutionDetails<T>(
+      value: defaultValue,
+      errorCode: ErrorCode.providerNotReady,
+      errorMessage: 'No provider has been configured.',
+      reason: 'ERROR',
+    );
+  }
+}

--- a/packages/openfeature_dart_client_sdk/lib/src/provider.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/provider.dart
@@ -1,0 +1,93 @@
+import 'details.dart';
+import 'evaluation_context.dart';
+import 'events.dart';
+import 'hooks.dart';
+import 'immutable.dart';
+import 'metadata.dart';
+
+/// Current provider status for the static-context paradigm.
+enum ProviderStatus { notReady, ready, reconciling, stale, error, fatal }
+
+/// Resolves typed flag values from local provider state.
+abstract interface class FeatureProvider {
+  ProviderMetadata get metadata;
+
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  );
+
+  ResolutionDetails<String> resolveStringValue(
+    String flagKey,
+    String defaultValue,
+    EvaluationContext context,
+  );
+
+  ResolutionDetails<int> resolveIntegerValue(
+    String flagKey,
+    int defaultValue,
+    EvaluationContext context,
+  );
+
+  ResolutionDetails<double> resolveDoubleValue(
+    String flagKey,
+    double defaultValue,
+    EvaluationContext context,
+  );
+
+  ResolutionDetails<Map<String, Object?>> resolveStructureValue(
+    String flagKey,
+    Map<String, Object?> defaultValue,
+    EvaluationContext context,
+  );
+}
+
+/// Optional provider initialization capability.
+abstract interface class InitializableProvider {
+  Future<void> initialize(EvaluationContext context, {String? domain});
+}
+
+/// Optional provider shutdown capability.
+abstract interface class ShutdownProvider {
+  Future<void> shutdown();
+}
+
+/// Optional provider context-reconciliation capability.
+abstract interface class ContextReconciliationProvider {
+  Future<void> onContextChanged(
+    EvaluationContext previousContext,
+    EvaluationContext newContext,
+  );
+}
+
+/// Marks a provider instance as valid for one domain only.
+abstract interface class DomainScopedProvider {}
+
+/// Optional provider event capability.
+abstract interface class ProviderEventSource {
+  Stream<ProviderEvent> get events;
+}
+
+/// Optional provider hooks capability.
+abstract interface class ProviderHooks {
+  List<Hook> get hooks;
+}
+
+/// Optional provider tracking capability.
+abstract interface class TrackingProvider {
+  void track(
+    String trackingEventName,
+    EvaluationContext context, {
+    TrackingEventDetails? details,
+  });
+}
+
+/// Data associated with one tracking call.
+final class TrackingEventDetails {
+  TrackingEventDetails({this.value, Map<String, Object?> attributes = const {}})
+    : attributes = immutableStructure(attributes, path: 'trackingAttributes');
+
+  final num? value;
+  final Map<String, Object?> attributes;
+}

--- a/packages/openfeature_dart_client_sdk/pubspec.yaml
+++ b/packages/openfeature_dart_client_sdk/pubspec.yaml
@@ -1,0 +1,18 @@
+name: openfeature_dart_client_sdk
+description: Official static-context Dart client SDK for OpenFeature.
+version: 0.0.1-beta.1
+homepage: https://github.com/open-feature/dart-server-sdk
+repository: https://github.com/open-feature/dart-server-sdk
+issue_tracker: https://github.com/open-feature/dart-server-sdk/issues
+
+environment:
+  sdk: ^3.12.2
+
+dev_dependencies:
+  # Keep minimum-dependency tests on analyzer dependencies compatible with Dart 3.12.
+  analyzer: ^8.1.1
+  coverage: ^1.15.0
+  # Dart 3.12 requires the SDK-layout-aware frontend server client.
+  frontend_server_client: ^4.0.0
+  lints: ^6.0.0
+  test: ^1.26.3

--- a/packages/openfeature_dart_client_sdk/test/client_sdk_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/client_sdk_test.dart
@@ -1,0 +1,679 @@
+import 'dart:async';
+
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk.dart';
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk_experimental.dart'
+    show createIsolatedOpenFeatureAPI;
+import 'package:test/test.dart';
+
+void main() {
+  late OpenFeatureAPI api;
+
+  setUp(() {
+    api = createIsolatedOpenFeatureAPI();
+  });
+
+  tearDown(() => api.shutdown());
+
+  group('API and client', () {
+    test(
+      'default singleton and isolated APIs keep independent state',
+      () async {
+        final isolatedA = createIsolatedOpenFeatureAPI();
+        final isolatedB = createIsolatedOpenFeatureAPI();
+        addTearDown(isolatedA.shutdown);
+        addTearDown(isolatedB.shutdown);
+
+        await isolatedA.setProviderAndWait(InMemoryProvider({'flag': true}));
+
+        expect(OpenFeatureAPI.instance, same(OpenFeatureAPI.instance));
+        expect(isolatedA, isNot(same(isolatedB)));
+        expect(isolatedA.getClient().getBooleanValue('flag', false), isTrue);
+        expect(isolatedB.getClient().getBooleanValue('flag', false), isFalse);
+      },
+    );
+
+    test('no-op provider returns the application default', () {
+      final client = api.getClient();
+
+      final details = client.getBooleanDetails('missing', true);
+
+      expect(details.value, isTrue);
+      expect(details.flagKey, 'missing');
+      expect(details.errorCode, ErrorCode.providerNotReady);
+      expect(details.flagMetadata, isEmpty);
+      expect(client.providerStatus, ProviderStatus.notReady);
+    });
+
+    test('client evaluation methods do not accept evaluation context', () {
+      final client = api.getClient();
+
+      final bool Function(String, bool, {EvaluationOptions? options}) evaluate =
+          client.getBooleanValue;
+
+      expect(evaluate('flag', false), isFalse);
+    });
+
+    test(
+      'domain clients select a domain provider and global fallback',
+      () async {
+        await api.setProviderAndWait(InMemoryProvider({'flag': false}));
+        await api.setProviderForDomainAndWait(
+          'checkout',
+          InMemoryProvider({'flag': true}),
+        );
+
+        expect(api.getClient().getBooleanValue('flag', true), isFalse);
+        expect(
+          api.getClient('checkout').getBooleanValue('flag', false),
+          isTrue,
+        );
+        expect(api.getClient('unknown').getBooleanValue('flag', true), isFalse);
+        expect(api.getClient('checkout').metadata.domain, 'checkout');
+        expect(api.getClient('checkout').metadata.name, 'checkout');
+      },
+    );
+
+    test('provider exceptions never escape flag evaluation', () async {
+      await api.setProviderAndWait(_ThrowingProvider());
+
+      final details = api.getClient().getStringDetails('flag', 'default');
+
+      expect(details.value, 'default');
+      expect(details.errorCode, ErrorCode.general);
+      expect(details.reason, 'ERROR');
+    });
+
+    test('provider errors cannot replace the application default', () async {
+      await api.setProviderAndWait(_InvalidErrorValueProvider());
+
+      final details = api.getClient().getBooleanDetails('flag', false);
+
+      expect(details.value, isFalse);
+      expect(details.errorCode, ErrorCode.flagNotFound);
+    });
+  });
+
+  group('evaluation types', () {
+    test('evaluation context is deeply immutable', () {
+      final source = <String, Object?>{
+        'groups': <Object?>[
+          <String, Object?>{'name': 'admin'},
+        ],
+      };
+
+      final context = EvaluationContext(
+        targetingKey: 'user-123',
+        attributes: source,
+      );
+      (source['groups']! as List<Object?>).clear();
+
+      expect(context.targetingKey, 'user-123');
+      expect(context.getValue('groups'), hasLength(1));
+      expect(context.asMap()['targetingKey'], 'user-123');
+      expect(() => context.attributes['new'] = true, throwsUnsupportedError);
+      expect(
+        () => (context.getValue('groups')! as List<Object?>).clear(),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('flag metadata validates values and is immutable', () {
+      final details = FlagEvaluationDetails<bool>(
+        flagKey: 'flag',
+        value: true,
+        flagMetadata: {'cached': true, 'age': 2},
+      );
+
+      expect(details.flagMetadata, {'cached': true, 'age': 2});
+      expect(
+        () => details.flagMetadata['new'] = 'value',
+        throwsUnsupportedError,
+      );
+      expect(
+        () => flagMetadata({'nested': <String, Object>{}}),
+        throwsArgumentError,
+      );
+    });
+
+    test('evaluation context rejects unsupported field values', () {
+      expect(
+        () => EvaluationContext(attributes: {'value': Object()}),
+        throwsArgumentError,
+      );
+    });
+
+    test('evaluation context rejects a duplicate targeting key field', () {
+      expect(
+        () => EvaluationContext(
+          targetingKey: 'one',
+          attributes: {'targetingKey': 'two'},
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('in-memory provider', () {
+    test(
+      'resolves every Dart flag type and reports abnormal results',
+      () async {
+        await api.setProviderAndWait(
+          InMemoryProvider({
+            'boolean': true,
+            'string': 'value',
+            'integer': 42,
+            'double': 4.2,
+            'structure': <String, Object?>{
+              'items': <Object?>['one', 'two'],
+            },
+          }),
+        );
+        final client = api.getClient();
+
+        expect(client.getBooleanValue('boolean', false), isTrue);
+        expect(client.getStringValue('string', ''), 'value');
+        expect(client.getIntegerValue('integer', 0), 42);
+        expect(client.getDoubleValue('double', 0), 4.2);
+        expect(client.getStructureValue('structure', const {}), {
+          'items': ['one', 'two'],
+        });
+        expect(
+          client.getBooleanDetails('string', false).errorCode,
+          ErrorCode.typeMismatch,
+        );
+        expect(
+          client.getBooleanDetails('missing', false).errorCode,
+          ErrorCode.flagNotFound,
+        );
+      },
+    );
+
+    test('replaceAll emits the union of old and new flag keys', () async {
+      final provider = InMemoryProvider({'old': true, 'same': false});
+      final event = provider.events.first;
+
+      provider.replaceAll({'new': true, 'same': true});
+
+      expect(
+        await event,
+        isA<ProviderEvent>()
+            .having(
+              (value) => value.type,
+              'type',
+              ProviderEventType.configurationChanged,
+            )
+            .having((value) => value.flagsChanged, 'flagsChanged', [
+              'new',
+              'old',
+              'same',
+            ]),
+      );
+    });
+  });
+
+  group('hooks', () {
+    test(
+      'runs API, client, invocation, and provider hooks as a stack',
+      () async {
+        final calls = <String>[];
+        final provider = _HookProvider(
+          {'flag': true},
+          [_RecordingHook('provider', calls)],
+        );
+        await api.setProviderAndWait(provider);
+        api.addHooks([_RecordingHook('api', calls)]);
+        final client = api.getClient()
+          ..addHooks([_RecordingHook('client', calls)]);
+
+        final result = client.getBooleanValue(
+          'flag',
+          false,
+          options: EvaluationOptions(
+            hooks: [_RecordingHook('invocation', calls)],
+            hookHints: {'source': 'test'},
+          ),
+        );
+
+        expect(result, isTrue);
+        expect(calls, [
+          'api.before:test',
+          'client.before:test',
+          'invocation.before:test',
+          'provider.before:test',
+          'provider.after',
+          'invocation.after',
+          'client.after',
+          'api.after',
+          'provider.finally',
+          'invocation.finally',
+          'client.finally',
+          'api.finally',
+        ]);
+      },
+    );
+
+    test('contains before-hook failures and returns the default', () async {
+      final calls = <String>[];
+      final provider = _HookProvider({'flag': true}, const []);
+      await api.setProviderAndWait(provider);
+      final client = api.getClient()
+        ..addHooks([
+          _RecordingHook('first', calls, throwBefore: true),
+          _RecordingHook('skipped', calls),
+        ]);
+
+      final details = client.getBooleanDetails('flag', false);
+
+      expect(details.value, isFalse);
+      expect(details.errorCode, ErrorCode.general);
+      expect(provider.booleanCalls, 0);
+      expect(calls, [
+        'first.before:null',
+        'skipped.error',
+        'first.error',
+        'skipped.finally',
+        'first.finally',
+      ]);
+    });
+  });
+
+  group('tracking', () {
+    test('uses static context and immutable tracking details', () async {
+      final provider = _TrackingProvider();
+      final context = EvaluationContext(targetingKey: 'user-123');
+      final source = <String, Object?>{
+        'cart': <String, Object?>{'items': 2},
+      };
+      final details = TrackingEventDetails(value: 42, attributes: source);
+      await api.setEvaluationContextAndWait(context);
+      await api.setProviderAndWait(provider);
+
+      api.getClient().track('checkout', details: details);
+      (source['cart']! as Map<String, Object?>)['items'] = 3;
+
+      expect(provider.trackingEventName, 'checkout');
+      expect(provider.trackingContext, same(context));
+      expect(provider.trackingDetails?.attributes, {
+        'cart': {'items': 2},
+      });
+    });
+
+    test('contains provider tracking failures', () async {
+      await api.setProviderAndWait(_TrackingProvider(throwOnTrack: true));
+
+      expect(() => api.getClient().track('event'), returnsNormally);
+    });
+  });
+
+  group('provider lifecycle contracts', () {
+    test('waits for provider-owned ready event', () async {
+      final provider = _LifecycleProvider();
+
+      await api.setProviderAndWait(provider);
+
+      expect(provider.initialContext, same(EvaluationContext.empty));
+      expect(api.getClient().providerStatus, ProviderStatus.ready);
+    });
+
+    test('applies concurrent provider requests in call order', () async {
+      final slow = _DelayedLifecycleProvider();
+
+      final firstRequest = api.setProviderAndWait(slow);
+      final latestRequest = api.setProviderAndWait(
+        InMemoryProvider({'flag': true}),
+      );
+      slow.allowInitialization();
+      await Future.wait([firstRequest, latestRequest]);
+
+      expect(api.getClient().getBooleanValue('flag', false), isTrue);
+    });
+
+    test('waits for provider-owned context changed event', () async {
+      final provider = _LifecycleProvider();
+      await api.setProviderAndWait(provider);
+      final context = EvaluationContext(targetingKey: 'user-123');
+
+      await api.setEvaluationContextAndWait(context);
+
+      expect(provider.newContext, same(context));
+      expect(api.getClient().providerStatus, ProviderStatus.ready);
+    });
+
+    test('serializes rapid static-context changes', () async {
+      final provider = _LifecycleProvider();
+      await api.setProviderAndWait(provider);
+      final first = EvaluationContext(targetingKey: 'first');
+      final second = EvaluationContext(targetingKey: 'second');
+
+      final firstChange = api.setEvaluationContextAndWait(first);
+      final secondChange = api.setEvaluationContextAndWait(second);
+      await Future.wait([firstChange, secondChange]);
+
+      expect(provider.contextChanges, [
+        (EvaluationContext.empty, first),
+        (first, second),
+      ]);
+    });
+
+    test('requires event support for lifecycle methods', () async {
+      await expectLater(
+        api.setProviderAndWait(_LifecycleProviderWithoutEvents()),
+        throwsA(isA<OpenFeatureException>()),
+      );
+    });
+
+    test('keeps an error provider bound after failed initialization', () async {
+      final provider = _FailingLifecycleProvider();
+
+      await expectLater(
+        api.setProviderAndWait(provider),
+        throwsA(isA<OpenFeatureException>()),
+      );
+
+      final client = api.getClient();
+      expect(client.providerStatus, ProviderStatus.fatal);
+      expect(
+        client.getBooleanDetails('flag', false).errorCode,
+        ErrorCode.providerFatal,
+      );
+    });
+
+    test('rejects a second domain for a domain-scoped provider', () async {
+      final provider = _DomainScopedInMemoryProvider({'flag': true});
+      await api.setProviderForDomainAndWait('one', provider);
+
+      await expectLater(
+        api.setProviderForDomainAndWait('two', provider),
+        throwsA(isA<OpenFeatureException>()),
+      );
+
+      expect(api.getClient('one').getBooleanValue('flag', false), isTrue);
+      expect(api.getClient('two').getBooleanValue('flag', false), isFalse);
+    });
+
+    test('shuts a provider down after its final binding is removed', () async {
+      final first = _ShutdownProvider({'flag': true});
+      await api.setProviderAndWait(first);
+      await api.setProviderForDomainAndWait('shared', first);
+
+      await api.setProviderAndWait(InMemoryProvider());
+      expect(first.shutdownCalls, 0);
+
+      await api.setProviderForDomainAndWait('shared', InMemoryProvider());
+      expect(first.shutdownCalls, 1);
+    });
+  });
+}
+
+class _ThrowingProvider extends _TestProvider {
+  _ThrowingProvider() : super(const {});
+
+  @override
+  ResolutionDetails<String> resolveStringValue(
+    String flagKey,
+    String defaultValue,
+    EvaluationContext context,
+  ) {
+    throw StateError('provider failed');
+  }
+}
+
+class _InvalidErrorValueProvider extends _TestProvider {
+  _InvalidErrorValueProvider() : super(const {});
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) {
+    return ResolutionDetails<bool>(
+      value: true,
+      errorCode: ErrorCode.flagNotFound,
+      reason: 'ERROR',
+    );
+  }
+}
+
+class _LifecycleProvider extends _TestProvider
+    implements
+        InitializableProvider,
+        ContextReconciliationProvider,
+        ProviderEventSource {
+  _LifecycleProvider() : super(const {});
+
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+  EvaluationContext? initialContext;
+  EvaluationContext? newContext;
+  final List<(EvaluationContext, EvaluationContext)> contextChanges = [];
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  @override
+  Future<void> initialize(EvaluationContext context, {String? domain}) async {
+    initialContext = context;
+    _events.add(ProviderEvent(type: ProviderEventType.ready));
+  }
+
+  @override
+  Future<void> onContextChanged(
+    EvaluationContext previousContext,
+    EvaluationContext newContext,
+  ) async {
+    this.newContext = newContext;
+    contextChanges.add((previousContext, newContext));
+    _events
+      ..add(ProviderEvent(type: ProviderEventType.reconciling))
+      ..add(ProviderEvent(type: ProviderEventType.contextChanged));
+  }
+}
+
+class _LifecycleProviderWithoutEvents extends _TestProvider
+    implements InitializableProvider {
+  _LifecycleProviderWithoutEvents() : super(const {});
+
+  @override
+  Future<void> initialize(EvaluationContext context, {String? domain}) async {}
+}
+
+class _DelayedLifecycleProvider extends _TestProvider
+    implements InitializableProvider, ProviderEventSource {
+  _DelayedLifecycleProvider() : super(const {});
+
+  final Completer<void> _initializationGate = Completer<void>();
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  void allowInitialization() => _initializationGate.complete();
+
+  @override
+  Future<void> initialize(EvaluationContext context, {String? domain}) async {
+    await _initializationGate.future;
+    _events.add(ProviderEvent(type: ProviderEventType.ready));
+  }
+}
+
+class _FailingLifecycleProvider extends _TestProvider
+    implements InitializableProvider, ProviderEventSource {
+  _FailingLifecycleProvider() : super(const {});
+
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  @override
+  Future<void> initialize(EvaluationContext context, {String? domain}) async {
+    _events.add(
+      ProviderEvent(
+        type: ProviderEventType.error,
+        errorCode: ErrorCode.providerFatal,
+      ),
+    );
+  }
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) {
+    return ResolutionDetails<bool>(
+      value: defaultValue,
+      errorCode: ErrorCode.providerFatal,
+      reason: 'ERROR',
+    );
+  }
+}
+
+class _DomainScopedInMemoryProvider extends _TestProvider
+    implements DomainScopedProvider {
+  _DomainScopedInMemoryProvider(super.flags);
+}
+
+class _ShutdownProvider extends _TestProvider implements ShutdownProvider {
+  _ShutdownProvider(super.flags);
+
+  int shutdownCalls = 0;
+
+  @override
+  Future<void> shutdown() async {
+    shutdownCalls++;
+  }
+}
+
+class _HookProvider extends _TestProvider implements ProviderHooks {
+  _HookProvider(super.flags, this.hooks);
+
+  @override
+  final List<Hook> hooks;
+
+  int booleanCalls = 0;
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) {
+    booleanCalls++;
+    return super.resolveBooleanValue(flagKey, defaultValue, context);
+  }
+}
+
+class _TrackingProvider extends _TestProvider implements TrackingProvider {
+  _TrackingProvider({this.throwOnTrack = false}) : super(const {});
+
+  final bool throwOnTrack;
+  String? trackingEventName;
+  EvaluationContext? trackingContext;
+  TrackingEventDetails? trackingDetails;
+
+  @override
+  void track(
+    String trackingEventName,
+    EvaluationContext context, {
+    TrackingEventDetails? details,
+  }) {
+    if (throwOnTrack) {
+      throw StateError('tracking failed');
+    }
+    this.trackingEventName = trackingEventName;
+    trackingContext = context;
+    trackingDetails = details;
+  }
+}
+
+final class _RecordingHook extends HookAdapter {
+  _RecordingHook(this.name, this.calls, {this.throwBefore = false});
+
+  final String name;
+  final List<String> calls;
+  final bool throwBefore;
+
+  @override
+  void before(HookContext context, HookHints hints) {
+    calls.add('$name.before:${hints['source']}');
+    context.hookData['name'] = name;
+    if (throwBefore) {
+      throw StateError('before failed');
+    }
+  }
+
+  @override
+  void after(
+    HookContext context,
+    FlagEvaluationDetails<Object> details,
+    HookHints hints,
+  ) {
+    if (context.hookData['name'] != name) {
+      throw StateError('Hook data was not preserved.');
+    }
+    calls.add('$name.after');
+  }
+
+  @override
+  void error(HookContext context, Object error, HookHints hints) {
+    calls.add('$name.error');
+  }
+
+  @override
+  void finallyAfter(
+    HookContext context,
+    FlagEvaluationDetails<Object> details,
+    HookHints hints,
+  ) {
+    calls.add('$name.finally');
+  }
+}
+
+class _TestProvider implements FeatureProvider {
+  _TestProvider(Map<String, Object> flags)
+    : _provider = InMemoryProvider(flags);
+
+  final InMemoryProvider _provider;
+
+  @override
+  ProviderMetadata get metadata => _provider.metadata;
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) => _provider.resolveBooleanValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<double> resolveDoubleValue(
+    String flagKey,
+    double defaultValue,
+    EvaluationContext context,
+  ) => _provider.resolveDoubleValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<int> resolveIntegerValue(
+    String flagKey,
+    int defaultValue,
+    EvaluationContext context,
+  ) => _provider.resolveIntegerValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<String> resolveStringValue(
+    String flagKey,
+    String defaultValue,
+    EvaluationContext context,
+  ) => _provider.resolveStringValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<Map<String, Object?>> resolveStructureValue(
+    String flagKey,
+    Map<String, Object?> defaultValue,
+    EvaluationContext context,
+  ) => _provider.resolveStructureValue(flagKey, defaultValue, context);
+}

--- a/packages/openfeature_dart_client_sdk/test/client_sdk_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/client_sdk_test.dart
@@ -402,6 +402,38 @@ void main() {
       await api.setProviderForDomainAndWait('shared', InMemoryProvider());
       expect(first.shutdownCalls, 1);
     });
+
+    test(
+      'replacement shuts down a provider when event cleanup fails',
+      () async {
+        final provider = _CancelFailingShutdownProvider();
+        await api.setProviderAndWait(provider);
+
+        await expectLater(
+          api.setProviderAndWait(InMemoryProvider({'flag': true})),
+          throwsA(isA<StateError>()),
+        );
+
+        expect(provider.shutdownCalls, 1);
+        expect(api.getClient().getBooleanValue('flag', false), isTrue);
+      },
+    );
+
+    test(
+      'API shutdown remains unconditional when event cleanup fails',
+      () async {
+        final failingCleanup = _CancelFailingShutdownProvider();
+        final otherProvider = _ShutdownProvider(const {});
+        await api.setProviderAndWait(failingCleanup);
+        await api.setProviderForDomainAndWait('other', otherProvider);
+
+        await expectLater(api.shutdown(), throwsA(isA<StateError>()));
+
+        expect(failingCleanup.shutdownCalls, 1);
+        expect(otherProvider.shutdownCalls, 1);
+        expect(api.getClient().providerStatus, ProviderStatus.notReady);
+      },
+    );
   });
 }
 
@@ -541,6 +573,26 @@ class _ShutdownProvider extends _TestProvider implements ShutdownProvider {
   _ShutdownProvider(super.flags);
 
   int shutdownCalls = 0;
+
+  @override
+  Future<void> shutdown() async {
+    shutdownCalls++;
+  }
+}
+
+class _CancelFailingShutdownProvider extends _TestProvider
+    implements ProviderEventSource, ShutdownProvider {
+  _CancelFailingShutdownProvider() : super(const {});
+
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>(
+        onCancel: () =>
+            Future<void>.error(StateError('event subscription cleanup failed')),
+      );
+  int shutdownCalls = 0;
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
 
   @override
   Future<void> shutdown() async {

--- a/packages/openfeature_dart_client_sdk/test/coverage_contract_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/coverage_contract_test.dart
@@ -1,0 +1,330 @@
+import 'dart:async';
+
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk.dart';
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk_experimental.dart'
+    show createIsolatedOpenFeatureAPI;
+import 'package:test/test.dart';
+
+void main() {
+  late OpenFeatureAPI api;
+
+  setUp(() {
+    api = createIsolatedOpenFeatureAPI();
+  });
+
+  tearDown(() => api.shutdown());
+
+  test('non-awaiting mutators preserve ordered static context', () async {
+    final defaultProvider = _ImmediateLifecycleProvider(name: 'default');
+    final domainProvider = _ImmediateLifecycleProvider(name: 'domain');
+    final defaultReady = Completer<void>();
+    final domainReady = Completer<void>();
+    api.getClient().addHandler(ProviderEventType.ready, (details) {
+      if (details.providerMetadata.name == 'default' &&
+          !defaultReady.isCompleted) {
+        defaultReady.complete();
+      }
+    });
+    api.getClient('checkout').addHandler(ProviderEventType.ready, (details) {
+      if (details.providerMetadata.name == 'domain' &&
+          !domainReady.isCompleted) {
+        domainReady.complete();
+      }
+    });
+
+    api.setProvider(defaultProvider);
+    await defaultReady.future;
+    api.setProviderForDomain('checkout', domainProvider);
+    await domainReady.future;
+    expect(api.getProviderMetadata().name, 'default');
+    expect(api.getProviderMetadata('checkout').name, 'domain');
+
+    final global = EvaluationContext(targetingKey: 'global');
+    api.setEvaluationContext(global);
+    await Future.wait([
+      defaultProvider.waitForChanges(1),
+      domainProvider.waitForChanges(1),
+    ]);
+
+    final domain = EvaluationContext(targetingKey: 'domain');
+    api.setEvaluationContextForDomain('checkout', domain);
+    await domainProvider.waitForChanges(2);
+    expect(domainProvider.changes.last, (global, domain));
+
+    api.clearEvaluationContextForDomain('checkout');
+    await domainProvider.waitForChanges(3);
+    expect(domainProvider.changes.last, (domain, global));
+
+    api.setEvaluationContextForDomain('unbound', domain);
+    await Future<void>.delayed(Duration.zero);
+    api.clearEvaluationContextForDomain('unbound');
+    await Future<void>.delayed(Duration.zero);
+
+    api.setProvider(defaultProvider);
+    api.setProviderForDomain('checkout', domainProvider);
+    await Future<void>.delayed(Duration.zero);
+    expect(defaultProvider.initializeCalls, 1);
+    expect(domainProvider.initializeCalls, 1);
+  });
+
+  test('non-awaiting lifecycle failures remain contained', () async {
+    final errors = <Object>[];
+
+    await runZonedGuarded(() async {
+      api.setProvider(_LifecycleProviderWithoutEvents());
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+    }, (error, _) => errors.add(error));
+
+    expect(errors, isEmpty);
+    expect(api.getClient().providerStatus, ProviderStatus.notReady);
+  });
+
+  test('no-op provider supports every typed evaluation method', () {
+    final client = api.getClient();
+
+    expect(client.getBooleanValue('flag', true), isTrue);
+    expect(client.getStringValue('flag', 'default'), 'default');
+    expect(client.getIntegerValue('flag', 1), 1);
+    expect(client.getDoubleValue('flag', 1.5), 1.5);
+    expect(client.getStructureValue('flag', const {'safe': true}), {
+      'safe': true,
+    });
+  });
+
+  test('default hook stages and hook failures remain contained', () async {
+    await api.setProviderAndWait(InMemoryProvider({'flag': true}));
+    api.addHooks([const _EmptyHook(), _ThrowingFinalHook()]);
+    final client = api.getClient();
+
+    expect(client.getBooleanValue('flag', false), isTrue);
+    expect(client.getBooleanValue('missing', false), isFalse);
+  });
+
+  test(
+    'provider metadata and OpenFeature exceptions return defaults',
+    () async {
+      await api.setProviderAndWait(_LateMetadataFailureProvider());
+      var details = api.getClient().getBooleanDetails('flag', false);
+
+      expect(details.value, isFalse);
+      expect(details.errorCode, ErrorCode.general);
+
+      await api.setProviderAndWait(_OpenFeatureThrowingProvider());
+      details = api.getClient().getBooleanDetails('flag', false);
+      expect(details.value, isFalse);
+      expect(details.errorCode, ErrorCode.providerFatal);
+      expect(
+        const OpenFeatureException(
+          'fatal',
+          errorCode: ErrorCode.providerFatal,
+        ).toString(),
+        'OpenFeatureException: fatal (providerFatal)',
+      );
+    },
+  );
+
+  test('reconciliation errors preserve the previous active context', () async {
+    final provider = _ReconciliationErrorProvider();
+    await api.setProviderAndWait(provider);
+
+    await expectLater(
+      api.setEvaluationContextAndWait(
+        EvaluationContext(targetingKey: 'rejected'),
+      ),
+      throwsA(
+        isA<OpenFeatureException>().having(
+          (error) => error.errorCode,
+          'errorCode',
+          ErrorCode.general,
+        ),
+      ),
+    );
+
+    expect(api.getClient().providerStatus, ProviderStatus.error);
+    api.getClient().getBooleanValue('flag', false);
+    expect(provider.lastEvaluationContext, same(EvaluationContext.empty));
+    await api.setProviderAndWait(InMemoryProvider({'flag': true}));
+    expect(api.getClient().getBooleanValue('flag', false), isTrue);
+  });
+
+  test('invalid nested values and flags report their exact boundary', () {
+    expect(
+      () => EvaluationContext(
+        attributes: {
+          'invalid': <Object?, Object?>{1: true},
+        },
+      ),
+      throwsArgumentError,
+    );
+    expect(() => InMemoryProvider({'flag': Object()}), throwsArgumentError);
+  });
+}
+
+final class _EmptyHook extends HookAdapter {
+  const _EmptyHook();
+}
+
+final class _ThrowingFinalHook extends HookAdapter {
+  @override
+  void finallyAfter(
+    HookContext context,
+    FlagEvaluationDetails<Object> details,
+    HookHints hints,
+  ) {
+    throw StateError('finally failed');
+  }
+}
+
+class _DelegatingProvider implements FeatureProvider {
+  _DelegatingProvider([Map<String, Object> flags = const {'flag': true}])
+    : delegate = InMemoryProvider(flags);
+
+  final InMemoryProvider delegate;
+
+  @override
+  ProviderMetadata get metadata =>
+      const ProviderMetadata(name: 'test-provider');
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) => delegate.resolveBooleanValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<double> resolveDoubleValue(
+    String flagKey,
+    double defaultValue,
+    EvaluationContext context,
+  ) => delegate.resolveDoubleValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<int> resolveIntegerValue(
+    String flagKey,
+    int defaultValue,
+    EvaluationContext context,
+  ) => delegate.resolveIntegerValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<String> resolveStringValue(
+    String flagKey,
+    String defaultValue,
+    EvaluationContext context,
+  ) => delegate.resolveStringValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<Map<String, Object?>> resolveStructureValue(
+    String flagKey,
+    Map<String, Object?> defaultValue,
+    EvaluationContext context,
+  ) => delegate.resolveStructureValue(flagKey, defaultValue, context);
+}
+
+final class _LifecycleProviderWithoutEvents extends _DelegatingProvider
+    implements InitializableProvider {
+  @override
+  Future<void> initialize(EvaluationContext context, {String? domain}) async {}
+}
+
+final class _ImmediateLifecycleProvider extends _DelegatingProvider
+    implements
+        InitializableProvider,
+        ContextReconciliationProvider,
+        ProviderEventSource {
+  _ImmediateLifecycleProvider({required this.name});
+
+  final String name;
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+  final StreamController<int> _changeCounts = StreamController<int>.broadcast(
+    sync: true,
+  );
+  final List<(EvaluationContext, EvaluationContext)> changes = [];
+  int initializeCalls = 0;
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  @override
+  ProviderMetadata get metadata => ProviderMetadata(name: name);
+
+  @override
+  Future<void> initialize(EvaluationContext context, {String? domain}) async {
+    initializeCalls++;
+    _events.add(ProviderEvent(type: ProviderEventType.ready));
+  }
+
+  Future<void> waitForChanges(int count) async {
+    if (changes.length >= count) {
+      return;
+    }
+    await _changeCounts.stream.firstWhere((value) => value >= count);
+  }
+
+  @override
+  Future<void> onContextChanged(
+    EvaluationContext previousContext,
+    EvaluationContext newContext,
+  ) async {
+    changes.add((previousContext, newContext));
+    _events.add(ProviderEvent(type: ProviderEventType.contextChanged));
+    _changeCounts.add(changes.length);
+  }
+}
+
+final class _LateMetadataFailureProvider extends _DelegatingProvider {
+  var metadataCalls = 0;
+
+  @override
+  ProviderMetadata get metadata {
+    metadataCalls++;
+    if (metadataCalls > 1) {
+      throw StateError('metadata failed');
+    }
+    return super.metadata;
+  }
+}
+
+final class _OpenFeatureThrowingProvider extends _DelegatingProvider {
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) {
+    throw const OpenFeatureException(
+      'fatal',
+      errorCode: ErrorCode.providerFatal,
+    );
+  }
+}
+
+final class _ReconciliationErrorProvider extends _DelegatingProvider
+    implements ContextReconciliationProvider, ProviderEventSource {
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+  EvaluationContext? lastEvaluationContext;
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  @override
+  Future<void> onContextChanged(
+    EvaluationContext previousContext,
+    EvaluationContext newContext,
+  ) async {
+    _events.add(ProviderEvent(type: ProviderEventType.error));
+  }
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) {
+    lastEvaluationContext = context;
+    return super.resolveBooleanValue(flagKey, defaultValue, context);
+  }
+}

--- a/packages/openfeature_dart_client_sdk/test/event_handlers_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/event_handlers_test.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk.dart';
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk_experimental.dart'
+    show createIsolatedOpenFeatureAPI;
+import 'package:test/test.dart';
+
+void main() {
+  late OpenFeatureAPI api;
+
+  setUp(() {
+    api = createIsolatedOpenFeatureAPI();
+  });
+
+  tearDown(() => api.shutdown());
+
+  test('delivers ready after binding and status update', () async {
+    final apiEvents = <ProviderEventDetails>[];
+    final clientEvents = <ProviderEventDetails>[];
+    final client = api.getClient('checkout');
+    ProviderStatus? statusDuringHandler;
+    api.addHandler(ProviderEventType.ready, apiEvents.add);
+    client.addHandler(ProviderEventType.ready, (details) {
+      statusDuringHandler = client.providerStatus;
+      clientEvents.add(details);
+    });
+
+    await api.setProviderForDomainAndWait(
+      'checkout',
+      _EventProvider(name: 'checkout-provider'),
+    );
+
+    expect(statusDuringHandler, ProviderStatus.ready);
+    expect(apiEvents, hasLength(1));
+    expect(apiEvents.single.providerMetadata.name, 'checkout-provider');
+    expect(apiEvents.single.domain, 'checkout');
+    expect(clientEvents, hasLength(1));
+    expect(clientEvents.single.domain, 'checkout');
+  });
+
+  test('keeps associated handlers across provider changes', () async {
+    final first = _EventProvider(name: 'first');
+    final replacement = _EventProvider(name: 'replacement');
+    final apiEvents = <ProviderEventDetails>[];
+    final defaultEvents = <ProviderEventDetails>[];
+    final fallbackEvents = <ProviderEventDetails>[];
+    final domainEvents = <ProviderEventDetails>[];
+    api.addHandler(ProviderEventType.configurationChanged, apiEvents.add);
+    api.getClient().addHandler(
+      ProviderEventType.configurationChanged,
+      defaultEvents.add,
+    );
+    final fallbackClient = api.getClient('fallback');
+    final fallbackSubscription = fallbackClient.addHandler(
+      ProviderEventType.configurationChanged,
+      fallbackEvents.add,
+    );
+    api
+        .getClient('checkout')
+        .addHandler(ProviderEventType.configurationChanged, domainEvents.add);
+    await api.setProviderAndWait(first);
+    await api.setProviderForDomainAndWait(
+      'checkout',
+      _EventProvider(name: 'domain'),
+    );
+
+    first.emit(ProviderEventType.configurationChanged, flagsChanged: ['flag']);
+    await api.setProviderAndWait(replacement);
+    first.emit(ProviderEventType.configurationChanged);
+    replacement.emit(ProviderEventType.configurationChanged);
+    fallbackClient.removeHandler(fallbackSubscription);
+    replacement.emit(ProviderEventType.configurationChanged);
+
+    expect(apiEvents.map((event) => event.providerMetadata.name), [
+      'first',
+      'replacement',
+      'replacement',
+    ]);
+    expect(defaultEvents, hasLength(3));
+    expect(fallbackEvents, hasLength(2));
+    expect(domainEvents, isEmpty);
+    expect(fallbackSubscription.isActive, isFalse);
+  });
+
+  test('contains handler failures and protects event details', () async {
+    final provider = _EventProvider();
+    final delivered = <ProviderEventDetails>[];
+    api.addHandler(ProviderEventType.configurationChanged, (_) {
+      throw StateError('handler failed');
+    });
+    api.addHandler(ProviderEventType.configurationChanged, delivered.add);
+    await api.setProviderAndWait(provider);
+
+    expect(
+      () => provider.emit(
+        ProviderEventType.configurationChanged,
+        flagsChanged: ['one'],
+        metadata: {'cached': true},
+      ),
+      returnsNormally,
+    );
+
+    final details = delivered.single;
+    expect(details.flagsChanged, ['one']);
+    expect(details.metadata, {'cached': true});
+    expect(() => details.flagsChanged.add('two'), throwsUnsupportedError);
+    expect(() => details.metadata['new'] = true, throwsUnsupportedError);
+  });
+
+  test('late handlers receive the current lifecycle state', () async {
+    final provider = _EventProvider();
+    await api.setProviderAndWait(provider);
+    final readyEvents = <ProviderEventDetails>[];
+
+    api.getClient().addHandler(ProviderEventType.ready, readyEvents.add);
+    provider.emit(ProviderEventType.stale);
+    final staleEvents = <ProviderEventDetails>[];
+    api.getClient().addHandler(ProviderEventType.stale, staleEvents.add);
+    provider.emit(ProviderEventType.error, errorCode: ErrorCode.providerFatal);
+    final errorEvents = <ProviderEventDetails>[];
+    api.getClient().addHandler(ProviderEventType.error, errorEvents.add);
+
+    expect(readyEvents, hasLength(1));
+    expect(staleEvents, hasLength(1));
+    expect(api.getClient().providerStatus, ProviderStatus.fatal);
+    expect(errorEvents.single.errorCode, ErrorCode.providerFatal);
+  });
+
+  test('removal is idempotent and shutdown resets handlers', () async {
+    final events = <ProviderEventDetails>[];
+    final subscription = api.addHandler(
+      ProviderEventType.configurationChanged,
+      events.add,
+    );
+    final provider = _EventProvider();
+    await api.setProviderAndWait(provider);
+
+    subscription.cancel();
+    subscription.cancel();
+    provider.emit(ProviderEventType.configurationChanged);
+    expect(events, isEmpty);
+
+    final active = api.addHandler(
+      ProviderEventType.configurationChanged,
+      events.add,
+    );
+    expect(active.isActive, isTrue);
+    await api.shutdown();
+    expect(active.isActive, isFalse);
+  });
+}
+
+final class _EventProvider implements FeatureProvider, ProviderEventSource {
+  _EventProvider({this.name = 'event-provider'})
+    : _delegate = InMemoryProvider({'flag': true});
+
+  final String name;
+  final InMemoryProvider _delegate;
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  @override
+  ProviderMetadata get metadata => ProviderMetadata(name: name);
+
+  void emit(
+    ProviderEventType type, {
+    Iterable<String> flagsChanged = const [],
+    ErrorCode? errorCode,
+    Map<String, Object> metadata = const {},
+  }) {
+    _events.add(
+      ProviderEvent(
+        type: type,
+        flagsChanged: flagsChanged,
+        errorCode: errorCode,
+        metadata: metadata,
+      ),
+    );
+  }
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveBooleanValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<double> resolveDoubleValue(
+    String flagKey,
+    double defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveDoubleValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<int> resolveIntegerValue(
+    String flagKey,
+    int defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveIntegerValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<String> resolveStringValue(
+    String flagKey,
+    String defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveStringValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<Map<String, Object?>> resolveStructureValue(
+    String flagKey,
+    Map<String, Object?> defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveStructureValue(flagKey, defaultValue, context);
+}

--- a/packages/openfeature_dart_client_sdk/test/race_safety_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/race_safety_test.dart
@@ -1,0 +1,226 @@
+import 'dart:async';
+
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk.dart';
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk_experimental.dart'
+    show createIsolatedOpenFeatureAPI;
+import 'package:test/test.dart';
+
+void main() {
+  late OpenFeatureAPI api;
+
+  setUp(() {
+    api = createIsolatedOpenFeatureAPI();
+  });
+
+  tearDown(() => api.shutdown());
+
+  test('provider replacement waits for active reconciliation', () async {
+    final original = _GatedContextProvider(name: 'original');
+    final replacement = _GatedContextProvider(name: 'replacement');
+    await api.setProviderAndWait(original);
+    final context = EvaluationContext(targetingKey: 'user-a');
+
+    final contextChange = api.setEvaluationContextAndWait(context);
+    await original.waitForChange(1);
+    final replacementRequest = api.setProviderAndWait(replacement);
+
+    expect(api.getClient().providerMetadata.name, 'original');
+    expect(replacement.changes, isEmpty);
+    original.allowChange(0);
+    await Future.wait([contextChange, replacementRequest]);
+
+    final client = api.getClient();
+    expect(client.providerMetadata.name, 'replacement');
+    expect(client.getBooleanValue('flag', false), isTrue);
+    expect(replacement.lastEvaluationContext, same(context));
+    expect(original.shutdownCalls, 1);
+
+    original.emit(ProviderEventType.contextChanged);
+    expect(client.providerStatus, ProviderStatus.ready);
+  });
+
+  test(
+    'shutdown waits for reconciliation and blocks late restoration',
+    () async {
+      final provider = _GatedContextProvider();
+      await api.setProviderAndWait(provider);
+      final contextChange = api.setEvaluationContextAndWait(
+        EvaluationContext(targetingKey: 'user-a'),
+      );
+      await provider.waitForChange(1);
+      var shutdownCompleted = false;
+
+      final shutdown = api.shutdown().then((_) {
+        shutdownCompleted = true;
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(shutdownCompleted, isFalse);
+      provider.allowChange(0);
+      await Future.wait([contextChange, shutdown]);
+
+      expect(provider.shutdownCalls, 1);
+      expect(api.getClient().providerStatus, ProviderStatus.notReady);
+      expect(api.getClient().getBooleanValue('flag', false), isFalse);
+      provider.emit(ProviderEventType.ready);
+      expect(api.getClient().providerStatus, ProviderStatus.notReady);
+    },
+  );
+
+  test(
+    'older context work cannot replace the latest active revision',
+    () async {
+      final provider = _GatedContextProvider();
+      await api.setProviderAndWait(provider);
+      final first = EvaluationContext(targetingKey: 'first');
+      final second = EvaluationContext(targetingKey: 'second');
+
+      final firstRequest = api.setEvaluationContextAndWait(first);
+      await provider.waitForChange(1);
+      final secondRequest = api.setEvaluationContextAndWait(second);
+      await Future<void>.delayed(Duration.zero);
+      expect(provider.changes, hasLength(1));
+
+      provider.allowChange(0);
+      await provider.waitForChange(2);
+      expect(provider.activeContext, same(first));
+      provider.allowChange(1);
+      await Future.wait([firstRequest, secondRequest]);
+
+      expect(provider.activeContext, same(second));
+      expect(provider.changes, [
+        (EvaluationContext.empty, first),
+        (first, second),
+      ]);
+      expect(api.getClient().getBooleanValue('flag', false), isTrue);
+      expect(provider.lastEvaluationContext, same(second));
+
+      provider.emit(ProviderEventType.contextChanged);
+      api.getClient().getBooleanValue('flag', false);
+      expect(provider.lastEvaluationContext, same(second));
+    },
+  );
+
+  test(
+    'different providers reconcile the global context concurrently',
+    () async {
+      final defaultProvider = _GatedContextProvider(name: 'default');
+      final domainProvider = _GatedContextProvider(name: 'domain');
+      await api.setProviderAndWait(defaultProvider);
+      await api.setProviderForDomainAndWait('checkout', domainProvider);
+
+      final contextChange = api.setEvaluationContextAndWait(
+        EvaluationContext(targetingKey: 'user-a'),
+      );
+      await Future.wait([
+        defaultProvider.waitForChange(1),
+        domainProvider.waitForChange(1),
+      ]);
+
+      defaultProvider.allowChange(0);
+      domainProvider.allowChange(0);
+      await contextChange;
+      expect(defaultProvider.activeContext.targetingKey, 'user-a');
+      expect(domainProvider.activeContext.targetingKey, 'user-a');
+    },
+  );
+}
+
+final class _GatedContextProvider
+    implements
+        FeatureProvider,
+        ContextReconciliationProvider,
+        ProviderEventSource,
+        ShutdownProvider {
+  _GatedContextProvider({this.name = 'gated-provider'})
+    : _delegate = InMemoryProvider({'flag': true});
+
+  final String name;
+  final InMemoryProvider _delegate;
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+  final StreamController<int> _starts = StreamController<int>.broadcast(
+    sync: true,
+  );
+  final List<Completer<void>> _gates = <Completer<void>>[];
+  final List<(EvaluationContext, EvaluationContext)> changes = [];
+  EvaluationContext activeContext = EvaluationContext.empty;
+  EvaluationContext? lastEvaluationContext;
+  int shutdownCalls = 0;
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  @override
+  ProviderMetadata get metadata => ProviderMetadata(name: name);
+
+  Future<void> waitForChange(int count) async {
+    if (changes.length >= count) {
+      return;
+    }
+    await _starts.stream.firstWhere((started) => started >= count);
+  }
+
+  void allowChange(int index) => _gates[index].complete();
+
+  void emit(ProviderEventType type) {
+    _events.add(ProviderEvent(type: type));
+  }
+
+  @override
+  Future<void> onContextChanged(
+    EvaluationContext previousContext,
+    EvaluationContext newContext,
+  ) async {
+    final gate = Completer<void>();
+    _gates.add(gate);
+    changes.add((previousContext, newContext));
+    _events.add(ProviderEvent(type: ProviderEventType.reconciling));
+    _starts.add(changes.length);
+    await gate.future;
+    activeContext = newContext;
+    _events.add(ProviderEvent(type: ProviderEventType.contextChanged));
+  }
+
+  @override
+  Future<void> shutdown() async {
+    shutdownCalls++;
+  }
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) {
+    lastEvaluationContext = context;
+    return _delegate.resolveBooleanValue(flagKey, defaultValue, context);
+  }
+
+  @override
+  ResolutionDetails<double> resolveDoubleValue(
+    String flagKey,
+    double defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveDoubleValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<int> resolveIntegerValue(
+    String flagKey,
+    int defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveIntegerValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<String> resolveStringValue(
+    String flagKey,
+    String defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveStringValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<Map<String, Object?>> resolveStructureValue(
+    String flagKey,
+    Map<String, Object?> defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveStructureValue(flagKey, defaultValue, context);
+}

--- a/packages/openfeature_dart_client_sdk/test/web_compile_smoke.dart
+++ b/packages/openfeature_dart_client_sdk/test/web_compile_smoke.dart
@@ -1,0 +1,7 @@
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk.dart';
+
+void main() {
+  final api = OpenFeatureAPI.createIsolated();
+  api.setProvider(InMemoryProvider({'web-compatible': true}));
+  api.getClient().getBooleanValue('web-compatible', false);
+}

--- a/packages/openfeature_dart_client_sdk/test/web_compile_smoke.dart
+++ b/packages/openfeature_dart_client_sdk/test/web_compile_smoke.dart
@@ -1,7 +1,7 @@
-import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk.dart';
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk_experimental.dart';
 
 void main() {
-  final api = OpenFeatureAPI.createIsolated();
+  final api = createIsolatedOpenFeatureAPI();
   api.setProvider(InMemoryProvider({'web-compatible': true}));
   api.getClient().getBooleanValue('web-compatible', false);
 }

--- a/tool/stage_client_package.dart
+++ b/tool/stage_client_package.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+Future<void> main(List<String> arguments) async {
+  final publish = arguments.contains('--publish');
+  final unknownArguments = arguments
+      .where((argument) => argument != '--publish' && argument != '--dry-run')
+      .toList(growable: false);
+  if (unknownArguments.isNotEmpty) {
+    stderr.writeln('Unknown arguments: ${unknownArguments.join(', ')}');
+    exitCode = 64;
+    return;
+  }
+
+  final script = File.fromUri(Platform.script);
+  final repositoryRoot = script.parent.parent;
+  final source = Directory(
+    _join(repositoryRoot.path, 'packages', 'openfeature_dart_client_sdk'),
+  );
+  final stagingRoot = await Directory.systemTemp.createTemp(
+    'openfeature_dart_client_sdk-',
+  );
+
+  try {
+    await _copyPackage(source, stagingRoot);
+    final commandArguments = <String>[
+      'pub',
+      'publish',
+      publish ? '--force' : '--dry-run',
+    ];
+    final process = await Process.start(
+      Platform.resolvedExecutable,
+      commandArguments,
+      workingDirectory: stagingRoot.path,
+      mode: ProcessStartMode.inheritStdio,
+    );
+    exitCode = await process.exitCode;
+  } finally {
+    if (stagingRoot.existsSync()) {
+      await stagingRoot.delete(recursive: true);
+    }
+  }
+}
+
+Future<void> _copyPackage(Directory source, Directory destination) async {
+  await for (final entity in source.list(recursive: true, followLinks: false)) {
+    final relativePath = entity.path.substring(source.path.length + 1);
+    if (_isExcluded(relativePath)) {
+      continue;
+    }
+    final targetPath = _join(destination.path, relativePath);
+    if (entity is Directory) {
+      await Directory(targetPath).create(recursive: true);
+    } else if (entity is File) {
+      await File(targetPath).parent.create(recursive: true);
+      await entity.copy(targetPath);
+    } else if (entity is Link) {
+      throw FileSystemException(
+        'Package staging does not support symbolic links.',
+        entity.path,
+      );
+    }
+  }
+}
+
+bool _isExcluded(String relativePath) {
+  final firstSegment = relativePath.split(Platform.pathSeparator).first;
+  return firstSegment == '.dart_tool' ||
+      firstSegment == 'build' ||
+      firstSegment == 'coverage' ||
+      firstSegment == 'pubspec.lock';
+}
+
+String _join(String first, String second, [String? third]) {
+  return [first, second, if (third != null) third].join(Platform.pathSeparator);
+}


### PR DESCRIPTION
## Motivation

Dart client applications lack a vendor-neutral OpenFeature SDK for the static-context paradigm. PR #118 approved the package design but did not add runtime code.

## Changes and Decisions

This change adds `openfeature_dart_client_sdk` as an independent pure-Dart beta package. It implements synchronous typed evaluation, immutable static context, provider lifecycle events, domain bindings, hooks, tracking, and an in-memory provider.

It keeps Flutter, transport, vendor code, persistent storage, and server relocation out of scope. Repository checks now validate both packages independently. The server archive excludes client source. Client publication uses an isolated staging directory because Pub applies the root `.pubignore` to nested packages.

The first beta publication remains a documented manual bootstrap before tag-bound OIDC publication.

Tracks #117.
Implements the first client scope approved in #118.