### PR TITLE
fix(client): harden beta promotion readiness

### DIFF
--- a/.github/workflows/contributor-workflow.yml
+++ b/.github/workflows/contributor-workflow.yml
@@ -51,16 +51,29 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          STATUS=0
+          set +e
           if [[ "$PACKAGE_PATH" == "." ]]; then
             PUBLISH_OUTPUT=$(dart pub publish --dry-run 2>&1)
+            STATUS=$?
           else
             PUBLISH_OUTPUT=$(dart ../../tool/stage_client_package.dart --dry-run 2>&1)
+            STATUS=$?
           fi
+          set -e
           echo "$PUBLISH_OUTPUT"
+          if [[ $STATUS -ne 0 ]]; then
+            exit "$STATUS"
+          fi
           if [[ "$PACKAGE_PATH" == "." ]] && grep -q "packages/openfeature_dart_client_sdk" <<< "$PUBLISH_OUTPUT"; then
             echo "The server package archive contains client package files." >&2
             exit 1
           fi
+
+      - name: Compile client web smoke target
+        if: matrix.package.name == 'client'
+        working-directory: ${{ matrix.package.path }}
+        run: dart compile js test/web_compile_smoke.dart -o build/web_compile_smoke.js
 
       - name: Run Static Analysis (capture and show)
         id: analyze

--- a/.github/workflows/coverage-workflow.yml
+++ b/.github/workflows/coverage-workflow.yml
@@ -54,6 +54,10 @@ jobs:
             /^LF:/ { lines_found += $2 }
             /^LH:/ { lines_hit += $2 }
             END {
+              if (lines_found == 0) {
+                print "Client coverage report contains no executable lines." > "/dev/stderr"
+                exit 1
+              }
               coverage = 100 * lines_hit / lines_found
               printf "Client line coverage: %d/%d (%.2f%%)\n", lines_hit, lines_found, coverage
               if (coverage < 95) exit 1

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -63,7 +63,10 @@ jobs:
       - name: Compile client web smoke target
         if: matrix.package.name == 'client'
         working-directory: ${{ matrix.package.path }}
-        run: dart compile js test/web_compile_smoke.dart -o build/web_compile_smoke.js
+        shell: bash
+        run: |
+          mkdir -p build
+          dart compile js test/web_compile_smoke.dart -o build/web_compile_smoke.js
 
   minimum-dependencies:
     name: minimum dependencies (${{ matrix.package.name }})
@@ -104,4 +107,7 @@ jobs:
       - name: Compile client web smoke target
         if: matrix.package.name == 'client'
         working-directory: ${{ matrix.package.path }}
-        run: dart compile js test/web_compile_smoke.dart -o build/web_compile_smoke.js
+        shell: bash
+        run: |
+          mkdir -p build
+          dart compile js test/web_compile_smoke.dart -o build/web_compile_smoke.js

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -60,6 +60,11 @@ jobs:
         working-directory: ${{ matrix.package.path }}
         run: dart test
 
+      - name: Compile client web smoke target
+        if: matrix.package.name == 'client'
+        working-directory: ${{ matrix.package.path }}
+        run: dart compile js test/web_compile_smoke.dart -o build/web_compile_smoke.js
+
   minimum-dependencies:
     name: minimum dependencies (${{ matrix.package.name }})
     if: >-
@@ -95,3 +100,8 @@ jobs:
       - name: Run tests
         working-directory: ${{ matrix.package.path }}
         run: dart test
+
+      - name: Compile client web smoke target
+        if: matrix.package.name == 'client'
+        working-directory: ${{ matrix.package.path }}
+        run: dart compile js test/web_compile_smoke.dart -o build/web_compile_smoke.js

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,9 +36,12 @@ jobs:
       - name: Publish client package
         if: >-
           ${{ startsWith(github.ref_name, 'openfeature_dart_client_sdk-v') &&
-              github.ref_name != 'openfeature_dart_client_sdk-v0.0.1-beta.1' }}
+              vars.CLIENT_PUBDEV_BOOTSTRAPPED == 'true' }}
         run: dart tool/stage_client_package.dart --publish
       - name: Explain first client publication
-        if: ${{ github.ref_name == 'openfeature_dart_client_sdk-v0.0.1-beta.1' }}
+        if: >-
+          ${{ startsWith(github.ref_name, 'openfeature_dart_client_sdk-v') &&
+              vars.CLIENT_PUBDEV_BOOTSTRAPPED != 'true' }}
         run: |
-          echo "The first client prerelease requires the documented manual pub.dev bootstrap."
+          echo "Client publishing is disabled until the first manual pub.dev bootstrap is complete."
+          echo "Follow doc/client-sdk-release.md, then set CLIENT_PUBDEV_BOOTSTRAPPED=true."

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 
 # Ignore Dart local build tools
 **/.dart_tool/
+**/build/
 **/pubspec.lock
-coverage/
+**/coverage/

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-  ".": "0.0.23"
+  ".": "0.0.23",
+  "packages/openfeature_dart_client_sdk": "0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -60,8 +60,13 @@ and published.
 - Read the [client SDK architecture](doc/client-sdk-architecture.md).
 - Review the
   [client SDK conformance matrix](doc/client-sdk-conformance-matrix.md).
+- Read the [client beta release procedure](doc/client-sdk-release.md).
 - Follow [issue #117](https://github.com/open-feature/dart-server-sdk/issues/117)
   for implementation progress.
+
+The nested client directory is a transitional beta layout. The client package
+name and import path are independently versioned; any later repository or
+folder move will be announced with migration guidance.
 
 ## Quick start
 

--- a/doc/client-sdk-architecture.md
+++ b/doc/client-sdk-architecture.md
@@ -238,8 +238,11 @@ binding and must use separate instances for independently scoped contexts.
 Initialization and reconciliation waits are bounded to 30 seconds by default.
 An isolated API may configure a shorter timeout for tests. A provider that
 returns without emitting the operation's terminal event fails within that
-bound, is released when it never became active, and cannot permanently block
-the serialized mutation queue or shutdown.
+bound and cannot permanently block the serialized mutation queue or shutdown.
+Because Dart futures cannot be cancelled, a timed-out provider is detached and
+quarantined from reuse; late events are ignored and callers must supply a new
+provider instance. Subscription cancellation and provider shutdown are bounded
+by the same lifecycle timeout.
 
 Tests cover sign-in, sign-out, account switching, queued rapid updates, refresh
 failure, provider replacement, shutdown during reconciliation, and late work

--- a/doc/client-sdk-architecture.md
+++ b/doc/client-sdk-architecture.md
@@ -229,9 +229,17 @@ before making a new binding active.
 A provider declaring itself domain-scoped can be bound to at most one domain,
 regardless of whether multiple domains currently have equal contexts. The SDK
 rejects a second domain binding and leaves the first intact. The bound domain is
-passed to initialization. A provider that does not declare itself domain-scoped
-may serve multiple domains; providers maintaining domain-specific caches or
-telemetry must declare themselves domain-scoped or use separate instances.
+passed to initialization. A provider that does not reconcile cached context may
+serve multiple domains because each resolver receives the selected context.
+Until the provider contract has a domain-aware reconciliation callback, a
+provider implementing `ContextReconciliationProvider` can have only one active
+binding and must use separate instances for independently scoped contexts.
+
+Initialization and reconciliation waits are bounded to 30 seconds by default.
+An isolated API may configure a shorter timeout for tests. A provider that
+returns without emitting the operation's terminal event fails within that
+bound, is released when it never became active, and cannot permanently block
+the serialized mutation queue or shutdown.
 
 Tests cover sign-in, sign-out, account switching, queued rapid updates, refresh
 failure, provider replacement, shutdown during reconciliation, and late work

--- a/doc/client-sdk-release.md
+++ b/doc/client-sdk-release.md
@@ -14,8 +14,11 @@ Automated pub.dev publishing can be configured only after a package exists.
 For `0.0.1-beta.1`, an authorized OpenFeature publisher must:
 
 1. Merge the reviewed client beta promotion to `main`.
-2. Merge the generated client release PR. Release Please updates the manifest
-   from `0.0.0` and creates the
+2. In the generated client release PR, remove the one-time `release-as` setting
+   from `release-please-config.json`. The repository test suite deliberately
+   rejects a non-bootstrap manifest that retains this override. Verify that the
+   PR still proposes `0.0.1-beta.1`, then merge it. Release Please updates the
+   manifest from `0.0.0` and creates the
    `openfeature_dart_client_sdk-v0.0.1-beta.1` tag.
 3. Check out that exact tag and run:
 
@@ -27,8 +30,7 @@ For `0.0.1-beta.1`, an authorized OpenFeature publisher must:
 4. Transfer the package to the verified `openfeature.dev` publisher on pub.dev.
 5. Configure pub.dev automated publishing for this GitHub repository and the
    `openfeature_dart_client_sdk-v*` tag pattern.
-6. Remove the one-time `release-as` setting for the client package.
-7. Set the GitHub repository variable `CLIENT_PUBDEV_BOOTSTRAPPED` to `true`.
+6. Set the GitHub repository variable `CLIENT_PUBDEV_BOOTSTRAPPED` to `true`.
 
 Until the repository variable is enabled, client release tags deliberately
 print bootstrap instructions instead of silently attempting publication.

--- a/doc/client-sdk-release.md
+++ b/doc/client-sdk-release.md
@@ -1,0 +1,45 @@
+# Dart Client SDK Beta Release
+
+The Dart client SDK is independently versioned from the server SDK. Client
+changes use the `openfeature_dart_client_sdk-v<version>` tag format and must not
+require a server package release. Release Please opens separate component pull
+requests so maintainers can merge the client release without publishing the
+server package. Because the server package remains temporarily at repository
+root, shared top-level monorepo commits may still appear in a proposed server
+release; review or close that proposal independently.
+
+## First pub.dev publication
+
+Automated pub.dev publishing can be configured only after a package exists.
+For `0.0.1-beta.1`, an authorized OpenFeature publisher must:
+
+1. Merge the reviewed client beta promotion to `main`.
+2. Merge the generated client release PR. Release Please updates the manifest
+   from `0.0.0` and creates the
+   `openfeature_dart_client_sdk-v0.0.1-beta.1` tag.
+3. Check out that exact tag and run:
+
+   ```text
+   dart tool/stage_client_package.dart --dry-run
+   dart tool/stage_client_package.dart --publish
+   ```
+
+4. Transfer the package to the verified `openfeature.dev` publisher on pub.dev.
+5. Configure pub.dev automated publishing for this GitHub repository and the
+   `openfeature_dart_client_sdk-v*` tag pattern.
+6. Remove the one-time `release-as` setting for the client package.
+7. Set the GitHub repository variable `CLIENT_PUBDEV_BOOTSTRAPPED` to `true`.
+
+Until the repository variable is enabled, client release tags deliberately
+print bootstrap instructions instead of silently attempting publication.
+
+## Later prereleases
+
+Release Please tracks the client from `packages/openfeature_dart_client_sdk`
+and creates component-prefixed beta tags. The tag-triggered publish workflow
+stages the nested package before publishing so the root server `.pubignore`
+cannot remove client files from its archive.
+
+Before every client release, verify formatting, analysis, tests, Dart web
+compilation, the staged pub.dev dry-run, and at least one external provider
+against the exact release commit.

--- a/packages/openfeature_dart_client_sdk/CHANGELOG.md
+++ b/packages/openfeature_dart_client_sdk/CHANGELOG.md
@@ -4,3 +4,8 @@
 
 - Add the initial static-context client API, provider contract, and hooks.
 - Add immutable evaluation types and an in-memory test provider.
+- Bound provider lifecycle waits and clean up failed initialization attempts.
+- Prevent unsafe provider reuse across APIs and independently scoped contexts.
+- Roll back successful providers when a global context change partially fails.
+- Preserve error and finally hooks when provider hook discovery fails.
+- Add independent prerelease automation and Dart web compilation checks.

--- a/packages/openfeature_dart_client_sdk/CHANGELOG.md
+++ b/packages/openfeature_dart_client_sdk/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Add the initial static-context client API, provider contract, and hooks.
 - Add immutable evaluation types and an in-memory test provider.
-- Bound provider lifecycle waits and clean up failed initialization attempts.
+- Bound provider lifecycle and cleanup waits; quarantine timed-out instances so
+  late asynchronous work cannot corrupt a later operation.
 - Prevent unsafe provider reuse across APIs and independently scoped contexts.
 - Roll back successful providers when a global context change partially fails.
 - Preserve error and finally hooks when provider hook discovery fails.

--- a/packages/openfeature_dart_client_sdk/README.md
+++ b/packages/openfeature_dart_client_sdk/README.md
@@ -55,6 +55,12 @@ a provider contract violation cannot indefinitely block context changes or
 shutdown. Tests and isolated integrations may select a shorter timeout through
 `createIsolatedOpenFeatureAPI(lifecycleTimeout: ...)`.
 
+When initialization or context reconciliation times out, the SDK quarantines
+and detaches that provider instance. Its underlying asynchronous work cannot be
+cancelled safely, so applications must register a new provider instance rather
+than retrying the timed-out one. Subscription cancellation and shutdown cleanup
+are bounded by the same timeout.
+
 A provider that implements `ContextReconciliationProvider` can have only one
 active API/domain binding. Use a separate provider instance for each static
 context. Providers that resolve entirely from the context passed to each

--- a/packages/openfeature_dart_client_sdk/README.md
+++ b/packages/openfeature_dart_client_sdk/README.md
@@ -50,7 +50,19 @@ Implement only the optional capabilities that the provider needs:
 
 An initializable or reconciling provider must also implement
 `ProviderEventSource`. It must emit the terminal lifecycle event before its
-method terminates.
+method terminates. The SDK bounds lifecycle waits to 30 seconds by default so
+a provider contract violation cannot indefinitely block context changes or
+shutdown. Tests and isolated integrations may select a shorter timeout through
+`createIsolatedOpenFeatureAPI(lifecycleTimeout: ...)`.
+
+A provider that implements `ContextReconciliationProvider` can have only one
+active API/domain binding. Use a separate provider instance for each static
+context. Providers that resolve entirely from the context passed to each
+resolver and do not reconcile cached state may be shared across domains.
+
+The package currently lives in the server SDK repository while the project
+validates the beta. Its package name and Dart import path are independent; a
+later repository move will be announced with migration guidance.
 
 ## Scope
 
@@ -67,3 +79,6 @@ parent package:
 ```text
 dart tool/stage_client_package.dart --dry-run
 ```
+
+See the [beta release procedure](../../doc/client-sdk-release.md) for the
+first-publication bootstrap and later automated prereleases.

--- a/packages/openfeature_dart_client_sdk/lib/src/api.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/api.dart
@@ -13,16 +13,23 @@ import 'provider.dart';
 /// Creates an API instance isolated from the process-wide singleton.
 ///
 /// This function is exported only from the experimental library.
-OpenFeatureAPI createIsolatedOpenFeatureAPI() => OpenFeatureAPI._();
+OpenFeatureAPI createIsolatedOpenFeatureAPI({
+  Duration lifecycleTimeout = const Duration(seconds: 30),
+}) => OpenFeatureAPI._(lifecycleTimeout: lifecycleTimeout);
 
 /// The static-context OpenFeature API.
 final class OpenFeatureAPI {
-  OpenFeatureAPI._();
+  OpenFeatureAPI._({this.lifecycleTimeout = const Duration(seconds: 30)});
 
   /// The process-wide default API instance.
   static final OpenFeatureAPI instance = OpenFeatureAPI._();
 
   static const FeatureProvider _noOpProvider = NoOpProvider();
+  static final Map<FeatureProvider, OpenFeatureAPI> _providerOwners =
+      HashMap<FeatureProvider, OpenFeatureAPI>.identity();
+
+  /// Maximum time allowed for one provider lifecycle operation.
+  final Duration lifecycleTimeout;
 
   FeatureProvider _defaultProvider = _noOpProvider;
   final Map<String, FeatureProvider> _domainProviders =
@@ -110,11 +117,29 @@ final class OpenFeatureAPI {
       )
       ..remove(_noOpProvider);
 
-    await Future.wait(
-      providers.map(
-        (provider) => _reconcile(provider, previousContext, context),
-      ),
+    final outcomes = await Future.wait(
+      providers.map((provider) async {
+        try {
+          await _reconcile(provider, context);
+          return (provider: provider, error: null, stackTrace: null);
+        } on Object catch (error, stackTrace) {
+          return (provider: provider, error: error, stackTrace: stackTrace);
+        }
+      }),
     );
+    final failures = outcomes.where((outcome) => outcome.error != null);
+    if (failures.isNotEmpty) {
+      final reconciledProviders = outcomes
+          .where((outcome) => outcome.error == null)
+          .map((outcome) => outcome.provider);
+      await Future.wait(
+        reconciledProviders.map(
+          (provider) => _reconcile(provider, previousContext),
+        ),
+      );
+      final failure = failures.first;
+      Error.throwWithStackTrace(failure.error!, failure.stackTrace!);
+    }
     _globalContext = context;
   }
 
@@ -140,10 +165,9 @@ final class OpenFeatureAPI {
     String domain,
     EvaluationContext context,
   ) async {
-    final previousContext = _contextForDomain(domain);
     final provider = _domainProviders[domain];
     if (provider != null) {
-      await _reconcile(provider, previousContext, context);
+      await _reconcile(provider, context);
     }
     _domainContexts[domain] = context;
   }
@@ -154,10 +178,9 @@ final class OpenFeatureAPI {
   }
 
   Future<void> _clearDomainContext(String domain) async {
-    final previousContext = _contextForDomain(domain);
     final provider = _domainProviders[domain];
     if (provider != null && _domainContexts.containsKey(domain)) {
-      await _reconcile(provider, previousContext, _globalContext);
+      await _reconcile(provider, _globalContext);
     }
     _domainContexts.remove(domain);
   }
@@ -231,23 +254,36 @@ final class OpenFeatureAPI {
     Object? initializationError;
     StackTrace? initializationStackTrace;
     if (record == null) {
+      final owner = _providerOwners[provider];
+      if (owner != null && !identical(owner, this)) {
+        throw const OpenFeatureException(
+          'A provider instance cannot be active in more than one API instance.',
+        );
+      }
       record = _ProviderRecord(
         initialDomain: domain,
         metadata: provider.metadata,
+        activeContext: _contextForDomain(domain),
       );
+      _providerOwners[provider] = this;
       _providerRecords[provider] = record;
       try {
         await _initialize(provider, record, domain);
       } on Object catch (error, stackTrace) {
         if (record.status != ProviderStatus.error &&
             record.status != ProviderStatus.fatal) {
-          await record.eventSubscription?.cancel();
-          _providerRecords.remove(provider);
+          await _disposeProvider(provider, record);
           rethrow;
         }
         initializationError = error;
         initializationStackTrace = stackTrace;
       }
+    } else if (provider is ContextReconciliationProvider &&
+        record.bindingCount > 0) {
+      throw const OpenFeatureException(
+        'A context-reconciling provider can have only one active binding. '
+        'Use a separate provider instance for each independently scoped context.',
+      );
     }
 
     if (domain == null) {
@@ -320,14 +356,24 @@ final class OpenFeatureAPI {
       );
     }
 
-    final terminalEvent = Completer<ProviderStatus>();
-    record.terminalEvent = terminalEvent;
+    final operation = _LifecycleOperation(ProviderEventType.ready);
+    record.lifecycleOperation = operation;
     try {
-      await (provider as InitializableProvider).initialize(
-        _contextForDomain(domain),
-        domain: domain,
-      );
-      final status = await terminalEvent.future;
+      final status =
+          await (() async {
+            await (provider as InitializableProvider).initialize(
+              _contextForDomain(domain),
+              domain: domain,
+            );
+            operation.completeCallback();
+            return operation.future;
+          })().timeout(
+            lifecycleTimeout,
+            onTimeout: () => throw OpenFeatureException(
+              'Provider initialization did not complete within '
+              '${lifecycleTimeout.inMilliseconds} ms.',
+            ),
+          );
       if (status == ProviderStatus.error || status == ProviderStatus.fatal) {
         throw OpenFeatureException(
           'Provider initialization ended with status ${status.name}.',
@@ -337,13 +383,14 @@ final class OpenFeatureAPI {
         );
       }
     } finally {
-      record.terminalEvent = null;
+      if (identical(record.lifecycleOperation, operation)) {
+        record.lifecycleOperation = null;
+      }
     }
   }
 
   Future<void> _reconcile(
     FeatureProvider provider,
-    EvaluationContext previousContext,
     EvaluationContext newContext,
   ) async {
     if (provider is! ContextReconciliationProvider) {
@@ -359,14 +406,25 @@ final class OpenFeatureAPI {
     if (record == null) {
       return;
     }
-    final terminalEvent = Completer<ProviderStatus>();
-    record.terminalEvent = terminalEvent;
+    final previousContext = record.activeContext;
+    final operation = _LifecycleOperation(ProviderEventType.contextChanged);
+    record.lifecycleOperation = operation;
     try {
-      await (provider as ContextReconciliationProvider).onContextChanged(
-        previousContext,
-        newContext,
-      );
-      final status = await terminalEvent.future;
+      final status =
+          await (() async {
+            await (provider as ContextReconciliationProvider).onContextChanged(
+              previousContext,
+              newContext,
+            );
+            operation.completeCallback();
+            return operation.future;
+          })().timeout(
+            lifecycleTimeout,
+            onTimeout: () => throw OpenFeatureException(
+              'Provider reconciliation did not complete within '
+              '${lifecycleTimeout.inMilliseconds} ms.',
+            ),
+          );
       if (status == ProviderStatus.error || status == ProviderStatus.fatal) {
         throw OpenFeatureException(
           'Provider reconciliation ended with status ${status.name}.',
@@ -375,8 +433,11 @@ final class OpenFeatureAPI {
               : ErrorCode.general,
         );
       }
+      record.activeContext = newContext;
     } finally {
-      record.terminalEvent = null;
+      if (identical(record.lifecycleOperation, operation)) {
+        record.lifecycleOperation = null;
+      }
     }
   }
 
@@ -411,14 +472,7 @@ final class OpenFeatureAPI {
       _dispatchEvent(provider, record, event);
     }
 
-    if (event.type == ProviderEventType.ready ||
-        event.type == ProviderEventType.contextChanged ||
-        event.type == ProviderEventType.error) {
-      final terminalEvent = record.terminalEvent;
-      if (terminalEvent != null && !terminalEvent.isCompleted) {
-        terminalEvent.complete(record.status);
-      }
-    }
+    record.lifecycleOperation?.observe(event, record.status);
   }
 
   ProviderEventSubscription _addHandler(
@@ -570,6 +624,9 @@ final class OpenFeatureAPI {
     } finally {
       record.status = ProviderStatus.notReady;
       _providerRecords.remove(provider);
+      if (identical(_providerOwners[provider], this)) {
+        _providerOwners.remove(provider);
+      }
     }
 
     if (cleanupError != null) {
@@ -750,18 +807,18 @@ final class OpenFeatureClient {
     final provider = _api._providerForDomain(metadata.domain);
     final evaluationContext = _api._contextForDomain(metadata.domain);
     final hints = options?.hookHints ?? HookHints();
-    late final List<Hook> hooks;
-    late final ProviderMetadata providerMetadata;
+    final hooks = <Hook>[..._api._hooks, ..._hooks, ...?options?.hooks];
+    ProviderMetadata providerMetadata =
+        _api._providerRecords[provider]?.metadata ??
+        const ProviderMetadata(name: 'unknown');
+    Object? setupError;
     try {
       providerMetadata = provider.metadata;
-      hooks = <Hook>[
-        ..._api._hooks,
-        ..._hooks,
-        ...?options?.hooks,
-        if (provider is ProviderHooks) ...(provider as ProviderHooks).hooks,
-      ];
+      if (provider is ProviderHooks) {
+        hooks.addAll((provider as ProviderHooks).hooks);
+      }
     } on Object catch (error) {
-      return _errorDetails(flagKey, defaultValue, error);
+      setupError = error;
     }
 
     final hookContexts = hooks
@@ -778,30 +835,34 @@ final class OpenFeatureClient {
         .toList(growable: false);
 
     FlagEvaluationDetails<T>? details;
-    Object? evaluationError;
+    Object? evaluationError = setupError;
     try {
-      for (var index = 0; index < hooks.length; index++) {
-        hooks[index].before(hookContexts[index], hints);
-      }
-      final resolution = resolve(provider, evaluationContext);
-      details = FlagEvaluationDetails<T>(
-        flagKey: flagKey,
-        value: resolution.errorCode == null ? resolution.value : defaultValue,
-        errorCode: resolution.errorCode,
-        errorMessage: resolution.errorMessage,
-        reason: resolution.reason,
-        variant: resolution.variant,
-        flagMetadata: resolution.flagMetadata,
-      );
-      if (resolution.errorCode != null) {
-        evaluationError = OpenFeatureException(
-          resolution.errorMessage ?? 'Provider resolution failed.',
-          errorCode: resolution.errorCode!,
-        );
-      } else {
-        for (var index = hooks.length - 1; index >= 0; index--) {
-          hooks[index].after(hookContexts[index], details, hints);
+      if (setupError == null) {
+        for (var index = 0; index < hooks.length; index++) {
+          hooks[index].before(hookContexts[index], hints);
         }
+        final resolution = resolve(provider, evaluationContext);
+        details = FlagEvaluationDetails<T>(
+          flagKey: flagKey,
+          value: resolution.errorCode == null ? resolution.value : defaultValue,
+          errorCode: resolution.errorCode,
+          errorMessage: resolution.errorMessage,
+          reason: resolution.errorCode == null ? resolution.reason : 'ERROR',
+          variant: resolution.variant,
+          flagMetadata: resolution.flagMetadata,
+        );
+        if (resolution.errorCode != null) {
+          evaluationError = OpenFeatureException(
+            resolution.errorMessage ?? 'Provider resolution failed.',
+            errorCode: resolution.errorCode!,
+          );
+        } else {
+          for (var index = hooks.length - 1; index >= 0; index--) {
+            hooks[index].after(hookContexts[index], details, hints);
+          }
+        }
+      } else {
+        details = _errorDetails(flagKey, defaultValue, setupError);
       }
     } on Object catch (error) {
       evaluationError = error;
@@ -883,13 +944,50 @@ final class _EventHandlerRecord {
 }
 
 final class _ProviderRecord {
-  _ProviderRecord({required this.initialDomain, required this.metadata});
+  _ProviderRecord({
+    required this.initialDomain,
+    required this.metadata,
+    required this.activeContext,
+  });
 
   final String? initialDomain;
   final ProviderMetadata metadata;
+  EvaluationContext activeContext;
   ProviderStatus status = ProviderStatus.notReady;
   int bindingCount = 0;
   StreamSubscription<ProviderEvent>? eventSubscription;
-  Completer<ProviderStatus>? terminalEvent;
+  _LifecycleOperation? lifecycleOperation;
   final List<ProviderEvent> pendingBindingEvents = <ProviderEvent>[];
+}
+
+final class _LifecycleOperation {
+  _LifecycleOperation(this.successEventType);
+
+  final ProviderEventType successEventType;
+  final Completer<ProviderStatus> _terminal = Completer<ProviderStatus>();
+  ProviderStatus? _latestStatus;
+  bool _callbackCompleted = false;
+
+  Future<ProviderStatus> get future => _terminal.future;
+
+  void observe(ProviderEvent event, ProviderStatus status) {
+    if (event.type != successEventType &&
+        event.type != ProviderEventType.error) {
+      return;
+    }
+    _latestStatus = status;
+    _completeIfReady();
+  }
+
+  void completeCallback() {
+    _callbackCompleted = true;
+    _completeIfReady();
+  }
+
+  void _completeIfReady() {
+    final status = _latestStatus;
+    if (_callbackCompleted && status != null && !_terminal.isCompleted) {
+      _terminal.complete(status);
+    }
+  }
 }

--- a/packages/openfeature_dart_client_sdk/lib/src/api.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/api.dart
@@ -27,6 +27,9 @@ final class OpenFeatureAPI {
   static const FeatureProvider _noOpProvider = NoOpProvider();
   static final Map<FeatureProvider, OpenFeatureAPI> _providerOwners =
       HashMap<FeatureProvider, OpenFeatureAPI>.identity();
+  static final Expando<bool> _quarantinedProviders = Expando<bool>(
+    'openfeature_quarantined_provider',
+  );
 
   /// Maximum time allowed for one provider lifecycle operation.
   final Duration lifecycleTimeout;
@@ -244,6 +247,12 @@ final class OpenFeatureAPI {
     FeatureProvider provider, {
     required String? domain,
   }) async {
+    if (_quarantinedProviders[provider] == true) {
+      throw const OpenFeatureException(
+        'A provider instance that timed out cannot be reused. '
+        'Create a replacement provider instance.',
+      );
+    }
     final current = _providerForExactBinding(domain);
     if (identical(current, provider)) {
       return;
@@ -270,10 +279,15 @@ final class OpenFeatureAPI {
       try {
         await _initialize(provider, record, domain);
       } on Object catch (error, stackTrace) {
-        if (record.status != ProviderStatus.error &&
-            record.status != ProviderStatus.fatal) {
-          await _disposeProvider(provider, record);
-          rethrow;
+        if (record.quarantined ||
+            (record.status != ProviderStatus.error &&
+                record.status != ProviderStatus.fatal)) {
+          try {
+            await _disposeProvider(provider, record);
+          } on Object {
+            // Preserve the initialization failure when cleanup also fails.
+          }
+          Error.throwWithStackTrace(error, stackTrace);
         }
         initializationError = error;
         initializationStackTrace = stackTrace;
@@ -358,6 +372,7 @@ final class OpenFeatureAPI {
 
     final operation = _LifecycleOperation(ProviderEventType.ready);
     record.lifecycleOperation = operation;
+    var timedOut = false;
     try {
       final status =
           await (() async {
@@ -369,10 +384,13 @@ final class OpenFeatureAPI {
             return operation.future;
           })().timeout(
             lifecycleTimeout,
-            onTimeout: () => throw OpenFeatureException(
-              'Provider initialization did not complete within '
-              '${lifecycleTimeout.inMilliseconds} ms.',
-            ),
+            onTimeout: () {
+              timedOut = true;
+              throw OpenFeatureException(
+                'Provider initialization did not complete within '
+                '${lifecycleTimeout.inMilliseconds} ms.',
+              );
+            },
           );
       if (status == ProviderStatus.error || status == ProviderStatus.fatal) {
         throw OpenFeatureException(
@@ -382,6 +400,11 @@ final class OpenFeatureAPI {
               : ErrorCode.general,
         );
       }
+    } on Object {
+      if (timedOut) {
+        _markProviderQuarantined(provider, record);
+      }
+      rethrow;
     } finally {
       if (identical(record.lifecycleOperation, operation)) {
         record.lifecycleOperation = null;
@@ -409,6 +432,7 @@ final class OpenFeatureAPI {
     final previousContext = record.activeContext;
     final operation = _LifecycleOperation(ProviderEventType.contextChanged);
     record.lifecycleOperation = operation;
+    var timedOut = false;
     try {
       final status =
           await (() async {
@@ -420,10 +444,13 @@ final class OpenFeatureAPI {
             return operation.future;
           })().timeout(
             lifecycleTimeout,
-            onTimeout: () => throw OpenFeatureException(
-              'Provider reconciliation did not complete within '
-              '${lifecycleTimeout.inMilliseconds} ms.',
-            ),
+            onTimeout: () {
+              timedOut = true;
+              throw OpenFeatureException(
+                'Provider reconciliation did not complete within '
+                '${lifecycleTimeout.inMilliseconds} ms.',
+              );
+            },
           );
       if (status == ProviderStatus.error || status == ProviderStatus.fatal) {
         throw OpenFeatureException(
@@ -434,6 +461,12 @@ final class OpenFeatureAPI {
         );
       }
       record.activeContext = newContext;
+    } on Object catch (error, stackTrace) {
+      if (timedOut) {
+        await _quarantineProvider(provider, record);
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+      rethrow;
     } finally {
       if (identical(record.lifecycleOperation, operation)) {
         record.lifecycleOperation = null;
@@ -446,6 +479,9 @@ final class OpenFeatureAPI {
     _ProviderRecord record,
     ProviderEvent event,
   ) {
+    if (record.quarantined || !identical(_providerRecords[provider], record)) {
+      return;
+    }
     switch (event.type) {
       case ProviderEventType.ready:
       case ProviderEventType.contextChanged:
@@ -601,27 +637,70 @@ final class OpenFeatureAPI {
     await _disposeProvider(provider, record);
   }
 
+  void _markProviderQuarantined(
+    FeatureProvider provider,
+    _ProviderRecord record,
+  ) {
+    record.quarantined = true;
+    _quarantinedProviders[provider] = true;
+  }
+
+  Future<void> _quarantineProvider(
+    FeatureProvider provider,
+    _ProviderRecord record,
+  ) async {
+    _markProviderQuarantined(provider, record);
+    if (identical(_defaultProvider, provider)) {
+      _defaultProvider = _noOpProvider;
+    }
+    _domainProviders.removeWhere((_, value) => identical(value, provider));
+    record.bindingCount = 0;
+    try {
+      await _disposeProvider(provider, record);
+    } on Object {
+      // The lifecycle timeout remains the primary failure reported to callers.
+    }
+  }
+
   Future<void> _disposeProvider(
     FeatureProvider provider,
     _ProviderRecord record,
   ) async {
     Object? cleanupError;
     StackTrace? cleanupStackTrace;
-    try {
-      await record.eventSubscription?.cancel();
-    } on Object catch (error, stackTrace) {
-      cleanupError = error;
-      cleanupStackTrace = stackTrace;
-    }
-
-    try {
-      if (provider is ShutdownProvider) {
-        await (provider as ShutdownProvider).shutdown();
+    final cleanup = () async {
+      try {
+        await record.eventSubscription?.cancel();
+      } on Object catch (error, stackTrace) {
+        cleanupError = error;
+        cleanupStackTrace = stackTrace;
       }
+
+      try {
+        if (provider is ShutdownProvider) {
+          await (provider as ShutdownProvider).shutdown();
+        }
+      } on Object catch (error, stackTrace) {
+        cleanupError ??= error;
+        cleanupStackTrace ??= stackTrace;
+      }
+    }();
+    try {
+      await cleanup.timeout(
+        lifecycleTimeout,
+        onTimeout: () => throw OpenFeatureException(
+          'Provider cleanup did not complete within '
+          '${lifecycleTimeout.inMilliseconds} ms.',
+        ),
+      );
     } on Object catch (error, stackTrace) {
       cleanupError ??= error;
       cleanupStackTrace ??= stackTrace;
     } finally {
+      record.eventSubscription = null;
+      record.lifecycleOperation = null;
+      record.pendingBindingEvents.clear();
+      record.bindingCount = 0;
       record.status = ProviderStatus.notReady;
       _providerRecords.remove(provider);
       if (identical(_providerOwners[provider], this)) {
@@ -629,8 +708,9 @@ final class OpenFeatureAPI {
       }
     }
 
-    if (cleanupError != null) {
-      Error.throwWithStackTrace(cleanupError, cleanupStackTrace!);
+    final error = cleanupError;
+    if (error != null) {
+      Error.throwWithStackTrace(error, cleanupStackTrace!);
     }
   }
 }
@@ -957,6 +1037,7 @@ final class _ProviderRecord {
   int bindingCount = 0;
   StreamSubscription<ProviderEvent>? eventSubscription;
   _LifecycleOperation? lifecycleOperation;
+  bool quarantined = false;
   final List<ProviderEvent> pendingBindingEvents = <ProviderEvent>[];
 }
 

--- a/packages/openfeature_dart_client_sdk/test/promotion_readiness_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/promotion_readiness_test.dart
@@ -31,6 +31,41 @@ void main() {
       },
     );
 
+    test(
+      'initialization timeout stays bounded when shutdown never returns',
+      () async {
+        final api = createIsolatedOpenFeatureAPI(
+          lifecycleTimeout: const Duration(milliseconds: 25),
+        );
+        final provider = _HungCleanupProvider();
+
+        await expectLater(
+          api.setProviderAndWait(provider).timeout(const Duration(seconds: 1)),
+          throwsA(
+            isA<OpenFeatureException>().having(
+              (error) => error.message,
+              'message',
+              contains('initialization did not complete'),
+            ),
+          ),
+        );
+
+        expect(provider.shutdownCalls, 1);
+        expect(api.getClient().providerStatus, ProviderStatus.notReady);
+        await expectLater(
+          api.setProviderAndWait(provider),
+          throwsA(
+            isA<OpenFeatureException>().having(
+              (error) => error.message,
+              'message',
+              contains('cannot be reused'),
+            ),
+          ),
+        );
+        await api.shutdown().timeout(const Duration(seconds: 1));
+      },
+    );
+
     test('the final lifecycle event at callback return wins', () async {
       final api = createIsolatedOpenFeatureAPI();
       addTearDown(api.shutdown);
@@ -141,6 +176,49 @@ void main() {
         expect(successful.lastEvaluationContext, same(EvaluationContext.empty));
       },
     );
+
+    test('a reconciliation timeout quarantines late provider work', () async {
+      final api = createIsolatedOpenFeatureAPI(
+        lifecycleTimeout: const Duration(milliseconds: 25),
+      );
+      addTearDown(api.shutdown);
+      final delayed = _DelayedContextProvider();
+      await api.setProviderAndWait(delayed);
+
+      await expectLater(
+        api.setEvaluationContextAndWait(
+          EvaluationContext(targetingKey: 'delayed'),
+        ),
+        throwsA(
+          isA<OpenFeatureException>().having(
+            (error) => error.message,
+            'message',
+            contains('reconciliation did not complete'),
+          ),
+        ),
+      );
+
+      expect(api.getClient().providerStatus, ProviderStatus.notReady);
+      await expectLater(
+        api.setProviderAndWait(delayed),
+        throwsA(
+          isA<OpenFeatureException>().having(
+            (error) => error.message,
+            'message',
+            contains('cannot be reused'),
+          ),
+        ),
+      );
+
+      final replacement = _ContextProvider();
+      await api.setProviderAndWait(replacement);
+      delayed.release();
+      await delayed.finished;
+
+      expect(api.getClient().providerStatus, ProviderStatus.ready);
+      api.getClient().getBooleanValue('flag', false);
+      expect(replacement.lastEvaluationContext, same(EvaluationContext.empty));
+    });
   });
 }
 
@@ -222,7 +300,17 @@ final class _ThrowingLifecycleProvider extends _SilentLifecycleProvider {
   }
 }
 
-final class _ContextProvider extends _DelegatingProvider
+final class _HungCleanupProvider extends _SilentLifecycleProvider {
+  final Completer<void> _never = Completer<void>();
+
+  @override
+  Future<void> shutdown() {
+    shutdownCalls++;
+    return _never.future;
+  }
+}
+
+class _ContextProvider extends _DelegatingProvider
     implements ContextReconciliationProvider, ProviderEventSource {
   _ContextProvider({this.failTargetingKey});
 
@@ -259,6 +347,28 @@ final class _ContextProvider extends _DelegatingProvider
   ) {
     lastEvaluationContext = context;
     return super.resolveBooleanValue(flagKey, defaultValue, context);
+  }
+}
+
+final class _DelayedContextProvider extends _ContextProvider {
+  final Completer<void> _release = Completer<void>();
+  final Completer<void> _finished = Completer<void>();
+
+  Future<void> get finished => _finished.future;
+
+  void release() => _release.complete();
+
+  @override
+  Future<void> onContextChanged(
+    EvaluationContext previousContext,
+    EvaluationContext newContext,
+  ) async {
+    await _release.future;
+    try {
+      await super.onContextChanged(previousContext, newContext);
+    } finally {
+      _finished.complete();
+    }
   }
 }
 

--- a/packages/openfeature_dart_client_sdk/test/promotion_readiness_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/promotion_readiness_test.dart
@@ -1,0 +1,288 @@
+import 'dart:async';
+
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk.dart';
+import 'package:openfeature_dart_client_sdk/openfeature_dart_client_sdk_experimental.dart'
+    show createIsolatedOpenFeatureAPI;
+import 'package:test/test.dart';
+
+void main() {
+  group('beta promotion lifecycle safety', () {
+    test(
+      'a missing terminal event times out and releases the provider',
+      () async {
+        final api = createIsolatedOpenFeatureAPI(
+          lifecycleTimeout: const Duration(milliseconds: 25),
+        );
+        final provider = _SilentLifecycleProvider();
+
+        await expectLater(
+          api.setProviderAndWait(provider),
+          throwsA(
+            isA<OpenFeatureException>().having(
+              (error) => error.message,
+              'message',
+              contains('did not complete'),
+            ),
+          ),
+        );
+
+        expect(provider.shutdownCalls, 1);
+        await api.shutdown().timeout(const Duration(seconds: 1));
+      },
+    );
+
+    test('the final lifecycle event at callback return wins', () async {
+      final api = createIsolatedOpenFeatureAPI();
+      addTearDown(api.shutdown);
+      final provider = _BackgroundErrorProvider();
+
+      await api.setProviderAndWait(provider);
+
+      expect(api.getClient().providerStatus, ProviderStatus.ready);
+    });
+
+    test('a provider that throws before an event is shut down', () async {
+      final api = createIsolatedOpenFeatureAPI();
+      addTearDown(api.shutdown);
+      final provider = _ThrowingLifecycleProvider();
+
+      await expectLater(
+        api.setProviderAndWait(provider),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(provider.shutdownCalls, 1);
+      expect(api.getClient().providerStatus, ProviderStatus.notReady);
+    });
+
+    test('context-aware providers cannot be shared across bindings', () async {
+      final api = createIsolatedOpenFeatureAPI();
+      addTearDown(api.shutdown);
+      final provider = _ContextProvider();
+
+      await api.setProviderForDomainAndWait('one', provider);
+
+      await expectLater(
+        api.setProviderForDomainAndWait('two', provider),
+        throwsA(
+          isA<OpenFeatureException>().having(
+            (error) => error.message,
+            'message',
+            contains('only one active binding'),
+          ),
+        ),
+      );
+    });
+
+    test('one provider instance cannot be active in two APIs', () async {
+      final firstApi = createIsolatedOpenFeatureAPI();
+      final secondApi = createIsolatedOpenFeatureAPI();
+      addTearDown(firstApi.shutdown);
+      addTearDown(secondApi.shutdown);
+      final provider = InMemoryProvider({'flag': true});
+
+      await firstApi.setProviderAndWait(provider);
+      await expectLater(
+        secondApi.setProviderAndWait(provider),
+        throwsA(isA<OpenFeatureException>()),
+      );
+
+      await firstApi.shutdown();
+      await secondApi.setProviderAndWait(provider);
+      expect(secondApi.getClient().getBooleanValue('flag', false), isTrue);
+    });
+  });
+
+  group('beta promotion evaluation and context safety', () {
+    test(
+      'API and client hooks observe provider hook discovery failures',
+      () async {
+        final api = createIsolatedOpenFeatureAPI();
+        addTearDown(api.shutdown);
+        final apiHook = _RecordingHook();
+        final clientHook = _RecordingHook();
+        api.addHooks([apiHook]);
+        await api.setProviderAndWait(_ThrowingHooksProvider());
+        final client = api.getClient()..addHooks([clientHook]);
+
+        final details = client.getBooleanDetails('flag', false);
+
+        expect(details.value, isFalse);
+        expect(details.reason, 'ERROR');
+        expect(apiHook.errors, 1);
+        expect(apiHook.finallyCalls, 1);
+        expect(clientHook.errors, 1);
+        expect(clientHook.finallyCalls, 1);
+      },
+    );
+
+    test(
+      'a partial global context failure rolls back successful providers',
+      () async {
+        final api = createIsolatedOpenFeatureAPI();
+        addTearDown(api.shutdown);
+        final successful = _ContextProvider();
+        final failing = _ContextProvider(failTargetingKey: 'rejected');
+        await api.setProviderAndWait(successful);
+        await api.setProviderForDomainAndWait('checkout', failing);
+        final rejected = EvaluationContext(targetingKey: 'rejected');
+
+        await expectLater(
+          api.setEvaluationContextAndWait(rejected),
+          throwsA(isA<OpenFeatureException>()),
+        );
+
+        expect(successful.activeContext, same(EvaluationContext.empty));
+        expect(successful.changes, [
+          (EvaluationContext.empty, rejected),
+          (rejected, EvaluationContext.empty),
+        ]);
+        successful.resolveBooleanValue('flag', false, EvaluationContext.empty);
+        expect(successful.lastEvaluationContext, same(EvaluationContext.empty));
+      },
+    );
+  });
+}
+
+class _DelegatingProvider implements FeatureProvider {
+  final InMemoryProvider _delegate = InMemoryProvider({'flag': true});
+
+  @override
+  ProviderMetadata get metadata =>
+      const ProviderMetadata(name: 'promotion-readiness-provider');
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveBooleanValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<double> resolveDoubleValue(
+    String flagKey,
+    double defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveDoubleValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<int> resolveIntegerValue(
+    String flagKey,
+    int defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveIntegerValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<String> resolveStringValue(
+    String flagKey,
+    String defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveStringValue(flagKey, defaultValue, context);
+
+  @override
+  ResolutionDetails<Map<String, Object?>> resolveStructureValue(
+    String flagKey,
+    Map<String, Object?> defaultValue,
+    EvaluationContext context,
+  ) => _delegate.resolveStructureValue(flagKey, defaultValue, context);
+}
+
+class _SilentLifecycleProvider extends _DelegatingProvider
+    implements InitializableProvider, ProviderEventSource, ShutdownProvider {
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+  int shutdownCalls = 0;
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  @override
+  Future<void> initialize(EvaluationContext context, {String? domain}) async {}
+
+  @override
+  Future<void> shutdown() async {
+    shutdownCalls++;
+    await _events.close();
+  }
+}
+
+final class _BackgroundErrorProvider extends _SilentLifecycleProvider {
+  @override
+  Future<void> initialize(EvaluationContext context, {String? domain}) async {
+    _events.add(ProviderEvent(type: ProviderEventType.error));
+    await Future<void>.delayed(Duration.zero);
+    _events.add(ProviderEvent(type: ProviderEventType.ready));
+  }
+}
+
+final class _ThrowingLifecycleProvider extends _SilentLifecycleProvider {
+  @override
+  Future<void> initialize(EvaluationContext context, {String? domain}) async {
+    throw StateError('initialization failed');
+  }
+}
+
+final class _ContextProvider extends _DelegatingProvider
+    implements ContextReconciliationProvider, ProviderEventSource {
+  _ContextProvider({this.failTargetingKey});
+
+  final String? failTargetingKey;
+  final StreamController<ProviderEvent> _events =
+      StreamController<ProviderEvent>.broadcast(sync: true);
+  final List<(EvaluationContext, EvaluationContext)> changes = [];
+  EvaluationContext activeContext = EvaluationContext.empty;
+  EvaluationContext? lastEvaluationContext;
+
+  @override
+  Stream<ProviderEvent> get events => _events.stream;
+
+  @override
+  Future<void> onContextChanged(
+    EvaluationContext previousContext,
+    EvaluationContext newContext,
+  ) async {
+    changes.add((previousContext, newContext));
+    if (failTargetingKey != null &&
+        newContext.targetingKey == failTargetingKey) {
+      _events.add(ProviderEvent(type: ProviderEventType.error));
+      return;
+    }
+    activeContext = newContext;
+    _events.add(ProviderEvent(type: ProviderEventType.contextChanged));
+  }
+
+  @override
+  ResolutionDetails<bool> resolveBooleanValue(
+    String flagKey,
+    bool defaultValue,
+    EvaluationContext context,
+  ) {
+    lastEvaluationContext = context;
+    return super.resolveBooleanValue(flagKey, defaultValue, context);
+  }
+}
+
+final class _ThrowingHooksProvider extends _DelegatingProvider
+    implements ProviderHooks {
+  @override
+  List<Hook> get hooks => throw StateError('hook discovery failed');
+}
+
+final class _RecordingHook extends HookAdapter {
+  int errors = 0;
+  int finallyCalls = 0;
+
+  @override
+  void error(HookContext context, Object error, HookHints hints) {
+    errors++;
+  }
+
+  @override
+  void finallyAfter(
+    HookContext context,
+    FlagEvaluationDetails<Object> details,
+    HookHints hints,
+  ) {
+    finallyCalls++;
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "signoff": "OpenFeature Bot <109696520+openfeaturebot@users.noreply.github.com>",
+  "separate-pull-requests": true,
   "packages": {
     ".": {
       "release-type": "dart",
@@ -7,6 +8,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,
+      "exclude-paths": [".github", "doc", "packages", "test", "tool"],
       "extra-files": ["README.md"],
       "changelog-sections": [
         {
@@ -60,6 +62,52 @@
           "type": "test",
           "hidden": true,
           "section": "🧪 Tests"
+        }
+      ]
+    },
+    "packages/openfeature_dart_client_sdk": {
+      "release-type": "dart",
+      "release-as": "0.0.1-beta.1",
+      "prerelease": true,
+      "prerelease-type": "beta",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "include-component-in-tag": true,
+      "changelog-sections": [
+        {
+          "type": "fix",
+          "section": "🐛 Bug Fixes"
+        },
+        {
+          "type": "feat",
+          "section": "✨ New Features"
+        },
+        {
+          "type": "docs",
+          "section": "📚 Documentation"
+        },
+        {
+          "type": "perf",
+          "section": "🚀 Performance"
+        },
+        {
+          "type": "deps",
+          "section": "📦 Dependencies"
+        },
+        {
+          "type": "chore",
+          "hidden": true,
+          "section": "🧹 Chore"
+        },
+        {
+          "type": "ci",
+          "hidden": true,
+          "section": "🚦 CI"
+        },
+        {
+          "type": "test",
+          "hidden": true,
+          "section": "✅ Tests"
         }
       ]
     }

--- a/test/release_please_config_test.dart
+++ b/test/release_please_config_test.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'client release-as is limited to the unpublished bootstrap manifest',
+    () {
+      final config =
+          jsonDecode(File('release-please-config.json').readAsStringSync())
+              as Map<String, Object?>;
+      final packages = config['packages']! as Map<String, Object?>;
+      final clientConfig =
+          packages['packages/openfeature_dart_client_sdk']!
+              as Map<String, Object?>;
+      final manifest =
+          jsonDecode(File('.release-please-manifest.json').readAsStringSync())
+              as Map<String, Object?>;
+      final clientVersion =
+          manifest['packages/openfeature_dart_client_sdk']! as String;
+
+      expect(
+        clientVersion == '0.0.0' || !clientConfig.containsKey('release-as'),
+        isTrue,
+        reason:
+            'Remove the one-time client release-as override in the first '
+            'release PR before merging it.',
+      );
+    },
+  );
+}

--- a/test/stage_client_package_test.dart
+++ b/test/stage_client_package_test.dart
@@ -1,0 +1,38 @@
+import 'package:test/test.dart';
+
+import '../tool/stage_client_package_paths.dart';
+
+void main() {
+  test('client staging excludes generated directories at any depth', () {
+    for (final path in <String>[
+      '.dart_tool/package_config.json',
+      'build/web_compile_smoke.js',
+      'coverage/lcov.info',
+      'test/coverage/stale.json',
+      'example/build/output.js',
+      'pubspec.lock',
+      'example/pubspec.lock',
+    ]) {
+      expect(
+        isExcludedClientPackagePath(path, pathSeparator: '/'),
+        isTrue,
+        reason: path,
+      );
+    }
+  });
+
+  test('client staging preserves package source and tests', () {
+    for (final path in <String>[
+      'lib/openfeature_dart_client_sdk.dart',
+      'test/client_sdk_test.dart',
+      'README.md',
+      '.pubignore',
+    ]) {
+      expect(
+        isExcludedClientPackagePath(path, pathSeparator: '/'),
+        isFalse,
+        reason: path,
+      );
+    }
+  });
+}

--- a/tool/stage_client_package.dart
+++ b/tool/stage_client_package.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'stage_client_package_paths.dart';
+
 Future<void> main(List<String> arguments) async {
   final publish = arguments.contains('--publish');
   final unknownArguments = arguments
@@ -44,7 +46,7 @@ Future<void> main(List<String> arguments) async {
 Future<void> _copyPackage(Directory source, Directory destination) async {
   await for (final entity in source.list(recursive: true, followLinks: false)) {
     final relativePath = entity.path.substring(source.path.length + 1);
-    if (_isExcluded(relativePath)) {
+    if (isExcludedClientPackagePath(relativePath)) {
       continue;
     }
     final targetPath = _join(destination.path, relativePath);
@@ -60,14 +62,6 @@ Future<void> _copyPackage(Directory source, Directory destination) async {
       );
     }
   }
-}
-
-bool _isExcluded(String relativePath) {
-  final firstSegment = relativePath.split(Platform.pathSeparator).first;
-  return firstSegment == '.dart_tool' ||
-      firstSegment == 'build' ||
-      firstSegment == 'coverage' ||
-      firstSegment == 'pubspec.lock';
 }
 
 String _join(String first, String second, [String? third]) {

--- a/tool/stage_client_package_paths.dart
+++ b/tool/stage_client_package_paths.dart
@@ -1,10 +1,7 @@
 import 'dart:io';
 
 /// Returns whether [relativePath] must be omitted from the staged client SDK.
-bool isExcludedClientPackagePath(
-  String relativePath, {
-  String? pathSeparator,
-}) {
+bool isExcludedClientPackagePath(String relativePath, {String? pathSeparator}) {
   const excludedSegments = <String>{'.dart_tool', 'build', 'coverage'};
   final segments = relativePath.split(pathSeparator ?? Platform.pathSeparator);
   return segments.any(excludedSegments.contains) ||

--- a/tool/stage_client_package_paths.dart
+++ b/tool/stage_client_package_paths.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+/// Returns whether [relativePath] must be omitted from the staged client SDK.
+bool isExcludedClientPackagePath(
+  String relativePath, {
+  String? pathSeparator,
+}) {
+  const excludedSegments = <String>{'.dart_tool', 'build', 'coverage'};
+  final segments = relativePath.split(pathSeparator ?? Platform.pathSeparator);
+  return segments.any(excludedSegments.contains) ||
+      segments.last == 'pubspec.lock';
+}


### PR DESCRIPTION
## Summary

Closes the promotion blockers raised on #148 while keeping the first client release intentionally beta-sized.

- bounds initialization, reconciliation, subscription cancellation, and shutdown cleanup
- quarantines timed-out provider instances so late work cannot corrupt a later operation
- correlates lifecycle completion with the operation's expected terminal event
- cleans up providers that throw before becoming active
- prevents unsafe cross-API and multi-context provider instance reuse
- rolls back successful providers after a partial global context failure
- preserves API/client error and finally hooks when provider hook discovery fails
- registers the client as an independent Release Please beta component
- separates server and client release pull requests and guards the one-time release-as bootstrap
- executes the Dart web compile smoke target and hardens archive/coverage diagnostics

## External provider evidence

The IntelliToggle `openfeature_provider_intellitoggle_client` alpha is pinned to exact candidate `fca61477e9cce4c81533b7c59525ccfc9f6076ff`. Its green pipeline validates the provider and a credential-free Flutter web example using backend-resolved snapshots:

https://gitlab.com/dartapps/apps/intellitoggle/openfeature-provider-intellitoggle/-/merge_requests/47

## Validation

- repository root: format, analyze, 184 tests
- client package: format, analyze, 51 tests
- client Dart JavaScript smoke compile
- server and staged-client publication dry-runs: 0 warnings
- full GitHub matrix: Dart 3.12.2/stable/beta on Linux, macOS, and Windows
- Release Please 17.11.2 local dry-run: independent server and client release PRs; client target `0.0.1-beta.1`
- IntelliToggle provider: analyze, 7 tests, JavaScript compile
- Flutter 3.47.1: analyze, 2 tests, release web build and successful Wasm dry run

Follow-up to #148. Relates to #117.