### PR TITLE
fix(ci): harden package-scoped contributor checks

### DIFF
--- a/.github/workflows/contributor-workflow.yml
+++ b/.github/workflows/contributor-workflow.yml
@@ -69,7 +69,9 @@ jobs:
       - name: Compile client web smoke target
         if: matrix.package.name == 'client'
         working-directory: ${{ matrix.package.path }}
-        run: dart compile js test/web_compile_smoke.dart -o build/web_compile_smoke.js
+        run: |
+          mkdir -p build
+          dart compile js test/web_compile_smoke.dart -o build/web_compile_smoke.js
 
       - name: Run client web smoke target in Chrome
         if: matrix.package.name == 'client'
@@ -140,7 +142,7 @@ jobs:
 
           for file in $FILES; do
             if [[ -f "$file" ]]; then
-              git_log=$(git -C "$GITHUB_WORKSPACE" log -n 1 --pretty=format:"%h by %an <%ae>" -- "$file" || true)
+              git_log=$(git log -n 1 --pretty=format:"%h by %an <%ae>" -- "$file" || true)
               echo "File: $file"
               echo "Last change: ${git_log:-unknown}"
               echo ""


### PR DESCRIPTION
## Summary

- create the client `build` directory before compiling the JavaScript smoke target
- resolve analyzer-reported paths from each package working directory when locating the last modifying commit

## Validation

- `git diff --check`
- package-relative `git log` lookup from the client package
- root repository test suite: 7 tests pass

Follow-up to the automated review on #148. No linked issue applies.

Signed-off-by: ABC2015 <6826984+ABC2015@users.noreply.github.com>