### PR TITLE
fix(release): prepare generated package changelogs

### DIFF
--- a/doc/client-sdk-release.md
+++ b/doc/client-sdk-release.md
@@ -7,6 +7,28 @@ requests so maintainers can merge the client release without publishing the
 server package. Both SDKs live under `packages/`, so Release Please can scope
 each proposal to the package directory that owns the change.
 
+## Bootstrap release set
+
+The repository-layout migration after server `v0.0.23` deliberately requires
+one server repackaging release, `0.0.24`, alongside the first client beta release
+proposal. This is a one-time migration decision rather than a coupling between
+the two package versions. Release Please must still open separate server and
+client release pull requests, and maintainers may review and merge them
+independently.
+
+Before merging the generated server `0.0.24` release pull request, curate its
+changelog to describe the server package move and the required Git dependency
+`path: packages/openfeature_dart_server_sdk`. Remove client-scoped changes and
+repository-only DCO or branch-sync entries from the server changelog. The full
+migration instructions remain in `doc/repository-layout-migration.md`.
+
+Release Please owns both package changelogs. Before the first client release,
+the client changelog contains only a non-rendered bootstrap marker mentioning
+`0.0.1-beta.1`, which keeps the package dry-run warning-free while allowing the
+generated entry to be the first visible heading. Do not prewrite that version
+heading. The server changelog must not carry an `Unreleased` block above its
+generated version entries.
+
 ## First pub.dev publication
 
 Automated pub.dev publishing can be configured only after a package exists.

--- a/packages/openfeature_dart_client_sdk/CHANGELOG.md
+++ b/packages/openfeature_dart_client_sdk/CHANGELOG.md
@@ -1,12 +1,1 @@
-# Changelog
-
-## 0.0.1-beta.1
-
-- Add the initial static-context client API, provider contract, and hooks.
-- Add immutable evaluation types and an in-memory test provider.
-- Bound provider lifecycle and cleanup waits; quarantine timed-out instances so
-  late asynchronous work cannot corrupt a later operation.
-- Prevent unsafe provider reuse across APIs and independently scoped contexts.
-- Roll back successful providers when a global context change partially fails.
-- Preserve error and finally hooks when provider hook discovery fails.
-- Add independent prerelease automation and Dart web compilation checks.
+<!-- Release Please will generate the 0.0.1-beta.1 entry. -->

--- a/packages/openfeature_dart_server_sdk/CHANGELOG.md
+++ b/packages/openfeature_dart_server_sdk/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Repository layout
-
-- Move the server package source to
-  `packages/openfeature_dart_server_sdk`. Pub.dev dependencies and Dart import
-  paths are unchanged. Git dependencies must set
-  `path: packages/openfeature_dart_server_sdk`.
-
 ## [0.0.23](https://github.com/open-feature/dart-server-sdk/compare/v0.0.22...v0.0.23) (2026-08-14)
 
 This release contains the first lifecycle and evaluation-safety work toward

--- a/test/release_please_config_test.dart
+++ b/test/release_please_config_test.dart
@@ -129,4 +129,41 @@ void main() {
       );
     },
   );
+
+  test('release changelogs have a single Release Please owner', () {
+    final manifest =
+        jsonDecode(File('.release-please-manifest.json').readAsStringSync())
+            as Map<String, Object?>;
+    final clientVersion =
+        manifest['packages/openfeature_dart_client_sdk']! as String;
+    final clientChangelog = File(
+      'packages/openfeature_dart_client_sdk/CHANGELOG.md',
+    ).readAsStringSync();
+    final serverChangelog = File(
+      'packages/openfeature_dart_server_sdk/CHANGELOG.md',
+    ).readAsStringSync();
+    final clientBetaHeadings = RegExp(
+      r'^## \[?0\.0\.1-beta\.1\]?',
+      multiLine: true,
+    ).allMatches(clientChangelog);
+
+    if (clientVersion == '0.0.0') {
+      expect(
+        clientChangelog.trim(),
+        '<!-- Release Please will generate the 0.0.1-beta.1 entry. -->',
+        reason:
+            'The bootstrap marker keeps pub validation warning-free while '
+            'Release Please creates the first visible changelog entry.',
+      );
+    } else {
+      expect(clientBetaHeadings, hasLength(1));
+    }
+    expect(
+      serverChangelog,
+      isNot(contains(RegExp(r'^## Unreleased$', multiLine: true))),
+      reason:
+          'Release Please inserts generated versions before numeric headings '
+          'and does not consume an Unreleased block.',
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- record the deliberate one-time server `0.0.24` repackaging release
- let Release Please own the first client beta entry and remove the server `Unreleased` block
- guard the bootstrap changelog state so generated releases cannot duplicate or strand headings

## Validation

- `dart analyze` (root tooling)
- `dart test` (17 tests)
- `dart tool/stage_client_package.dart --dry-run` (26 KB, 0 warnings)
- Release Please 17.6.0 changelog updater simulation: one client `0.0.1-beta.1` heading; server `0.0.24` directly above `0.0.23`

## Release follow-up

The generated server `0.0.24` release PR must be curated before merge so its changelog describes the package-layout migration and excludes client-scoped, DCO-remediation, and branch-sync entries.