### PR TITLE
fix(client): support Dart 3.6

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -36,17 +36,19 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [3.12.2, stable, beta]
+        sdk: [minimum, stable, beta]
         package:
           - name: server
             path: packages/openfeature_dart_server_sdk
+            minimum_sdk: 3.12.2
           - name: client
             path: packages/openfeature_dart_client_sdk
+            minimum_sdk: 3.6.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
         with:
-          sdk: ${{ matrix.sdk }}
+          sdk: ${{ matrix.sdk == 'minimum' && matrix.package.minimum_sdk || matrix.sdk }}
 
       - name: Install dependencies
         working-directory: ${{ matrix.package.path }}
@@ -72,7 +74,7 @@ jobs:
         if: >-
           matrix.package.name == 'client' &&
           matrix.os == 'ubuntu-latest' &&
-          matrix.sdk == '3.12.2'
+          matrix.sdk == 'minimum'
         working-directory: ${{ matrix.package.path }}
         run: dart test -p chrome test/web_compile_smoke.dart
 
@@ -109,13 +111,15 @@ jobs:
         package:
           - name: server
             path: packages/openfeature_dart_server_sdk
+            sdk: 3.12.2
           - name: client
             path: packages/openfeature_dart_client_sdk
+            sdk: 3.6.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
         with:
-          sdk: 3.12.2
+          sdk: ${{ matrix.package.sdk }}
 
       - name: Install minimum dependencies
         working-directory: ${{ matrix.package.path }}

--- a/.github/workflows/validation-workflow.yml
+++ b/.github/workflows/validation-workflow.yml
@@ -105,16 +105,27 @@ jobs:
           echo "Found the following pubspec.yaml files:"
           echo "$PUBSPEC_FILES"
 
-          # Define the minimum required Dart SDK version
-          MINIMUM_VERSION="3.12.2"
+          declare -A EXPECTED_MINIMUM_VERSIONS=(
+            ["./pubspec.yaml"]="3.12.2"
+            ["./packages/openfeature_dart_server_sdk/pubspec.yaml"]="3.12.2"
+            ["./packages/openfeature_dart_client_sdk/pubspec.yaml"]="3.6.0"
+          )
           ALL_VALID="true"
 
           # Iterate over each pubspec.yaml file
           for PUBSPEC in $PUBSPEC_FILES; do
             echo "Checking $PUBSPEC..."
 
-            # Extract the Dart SDK version in the ^<version> format
-            SDK_VERSION=$(grep -Po '(?<=sdk:\s\^)[0-9]+\.[0-9]+\.[0-9]+' "$PUBSPEC" || echo "not_found")
+            EXPECTED_MINIMUM_VERSION="${EXPECTED_MINIMUM_VERSIONS[$PUBSPEC]:-}"
+            if [ -z "$EXPECTED_MINIMUM_VERSION" ]; then
+              echo "❌ No expected minimum Dart SDK version is configured for $PUBSPEC."
+              ALL_VALID="false"
+              continue
+            fi
+
+            # Extract the lower bound from ^<version> or >=<version>.
+            SDK_VERSION=$(sed -nE "s/^[[:space:]]+sdk:[[:space:]]*['\"]?(\^|>=)([0-9]+\.[0-9]+\.[0-9]+).*/\2/p" "$PUBSPEC")
+            SDK_VERSION="${SDK_VERSION:-not_found}"
             echo "Extracted Dart SDK version from $PUBSPEC: $SDK_VERSION"
 
             # Validate the extracted version
@@ -124,9 +135,8 @@ jobs:
               continue
             fi
 
-            # Compare the version
-            if [[ $(echo -e "${SDK_VERSION}\n${MINIMUM_VERSION}" | sort -V | head -n1) != "$MINIMUM_VERSION" ]]; then
-              echo "❌ Dart SDK version in $PUBSPEC must be at least $MINIMUM_VERSION, found $SDK_VERSION"
+            if [ "$SDK_VERSION" != "$EXPECTED_MINIMUM_VERSION" ]; then
+              echo "❌ Dart SDK version in $PUBSPEC must start at $EXPECTED_MINIMUM_VERSION, found $SDK_VERSION"
               ALL_VALID="false"
             else
               echo "✅ Dart SDK version in $PUBSPEC is satisfactory: $SDK_VERSION"

--- a/packages/openfeature_dart_client_sdk/README.md
+++ b/packages/openfeature_dart_client_sdk/README.md
@@ -4,6 +4,8 @@ This package is the vendor-neutral OpenFeature SDK for Dart client
 applications. It uses the static-context paradigm. It has no Flutter or
 `dart:io` dependency.
 
+The package requires Dart 3.6 or later.
+
 The package is in beta. The first beta defines the public client and provider
 contracts. It provides synchronous typed evaluation, event handlers, hooks,
 ordered context changes, and an in-memory provider. Later beta changes will

--- a/packages/openfeature_dart_client_sdk/lib/src/api.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/api.dart
@@ -15,7 +15,8 @@ import 'provider.dart';
 /// This function is exported only from the experimental library.
 OpenFeatureAPI createIsolatedOpenFeatureAPI({
   Duration lifecycleTimeout = const Duration(seconds: 30),
-}) => OpenFeatureAPI._(lifecycleTimeout: lifecycleTimeout);
+}) =>
+    OpenFeatureAPI._(lifecycleTimeout: lifecycleTimeout);
 
 /// The static-context OpenFeature API.
 final class OpenFeatureAPI {
@@ -491,7 +492,7 @@ final class OpenFeatureAPI {
     ).then((_) => operation());
     final tail = result.then<void>(
       (_) {},
-      onError: (Object _, StackTrace _) {},
+      onError: (Object _, StackTrace __) {},
     );
     for (final key in keys) {
       _bindingMutationQueues[key] = tail;
@@ -523,7 +524,7 @@ final class OpenFeatureAPI {
     ).then((_) => operation());
     final tail = result.then<void>(
       (_) {},
-      onError: (Object _, StackTrace _) {},
+      onError: (Object _, StackTrace __) {},
     );
     for (final key in keys) {
       _providerMutationQueues[key] = tail;
@@ -546,7 +547,8 @@ final class OpenFeatureAPI {
     String? domain,
   ) async {
     if (provider is ProviderEventSource) {
-      record.eventSubscription = (provider as ProviderEventSource).events
+      record.eventSubscription = (provider as ProviderEventSource)
+          .events
           .listen((event) => _processEvent(provider, record, event));
     }
 
@@ -568,24 +570,24 @@ final class OpenFeatureAPI {
     record.lifecycleOperation = operation;
     var timedOut = false;
     try {
-      final status =
-          await (() async {
-            await (provider as InitializableProvider).initialize(
-              _requestedContextForDomain(domain),
-              domain: domain,
-            );
-            operation.completeCallback();
-            return operation.future;
-          })().timeout(
-            lifecycleTimeout,
-            onTimeout: () {
-              timedOut = true;
-              throw OpenFeatureException(
-                'Provider initialization did not complete within '
-                '${lifecycleTimeout.inMilliseconds} ms.',
-              );
-            },
+      final status = await (() async {
+        await (provider as InitializableProvider).initialize(
+          _requestedContextForDomain(domain),
+          domain: domain,
+        );
+        operation.completeCallback();
+        return operation.future;
+      })()
+          .timeout(
+        lifecycleTimeout,
+        onTimeout: () {
+          timedOut = true;
+          throw OpenFeatureException(
+            'Provider initialization did not complete within '
+            '${lifecycleTimeout.inMilliseconds} ms.',
           );
+        },
+      );
       if (status == ProviderStatus.error || status == ProviderStatus.fatal) {
         throw OpenFeatureException(
           'Provider initialization ended with status ${status.name}.',
@@ -632,24 +634,24 @@ final class OpenFeatureAPI {
     record.lifecycleOperation = operation;
     var timedOut = false;
     try {
-      final status =
-          await (() async {
-            await (provider as ContextReconciliationProvider).onContextChanged(
-              previousContext,
-              newContext,
-            );
-            operation.completeCallback();
-            return operation.future;
-          })().timeout(
-            lifecycleTimeout,
-            onTimeout: () {
-              timedOut = true;
-              throw OpenFeatureException(
-                'Provider reconciliation did not complete within '
-                '${lifecycleTimeout.inMilliseconds} ms.',
-              );
-            },
+      final status = await (() async {
+        await (provider as ContextReconciliationProvider).onContextChanged(
+          previousContext,
+          newContext,
+        );
+        operation.completeCallback();
+        return operation.future;
+      })()
+          .timeout(
+        lifecycleTimeout,
+        onTimeout: () {
+          timedOut = true;
+          throw OpenFeatureException(
+            'Provider reconciliation did not complete within '
+            '${lifecycleTimeout.inMilliseconds} ms.',
           );
+        },
+      );
       if (status == ProviderStatus.error || status == ProviderStatus.fatal) {
         throw OpenFeatureException(
           'Provider reconciliation ended with status ${status.name}.',
@@ -833,8 +835,7 @@ final class OpenFeatureAPI {
           handlerRecord.eventType != event.type) {
         continue;
       }
-      final isAssociated =
-          handlerRecord.apiWide ||
+      final isAssociated = handlerRecord.apiWide ||
           identical(_providerForDomain(handlerRecord.domain), provider);
       if (isAssociated) {
         _invokeHandler(handlerRecord, providerRecord, event);
@@ -1007,7 +1008,8 @@ final class OpenFeatureClient {
     String flagKey,
     bool defaultValue, {
     EvaluationOptions? options,
-  }) => getBooleanDetails(flagKey, defaultValue, options: options).value;
+  }) =>
+      getBooleanDetails(flagKey, defaultValue, options: options).value;
 
   FlagEvaluationDetails<bool> getBooleanDetails(
     String flagKey,
@@ -1028,7 +1030,8 @@ final class OpenFeatureClient {
     String flagKey,
     String defaultValue, {
     EvaluationOptions? options,
-  }) => getStringDetails(flagKey, defaultValue, options: options).value;
+  }) =>
+      getStringDetails(flagKey, defaultValue, options: options).value;
 
   FlagEvaluationDetails<String> getStringDetails(
     String flagKey,
@@ -1049,7 +1052,8 @@ final class OpenFeatureClient {
     String flagKey,
     int defaultValue, {
     EvaluationOptions? options,
-  }) => getIntegerDetails(flagKey, defaultValue, options: options).value;
+  }) =>
+      getIntegerDetails(flagKey, defaultValue, options: options).value;
 
   FlagEvaluationDetails<int> getIntegerDetails(
     String flagKey,
@@ -1070,7 +1074,8 @@ final class OpenFeatureClient {
     String flagKey,
     double defaultValue, {
     EvaluationOptions? options,
-  }) => getDoubleDetails(flagKey, defaultValue, options: options).value;
+  }) =>
+      getDoubleDetails(flagKey, defaultValue, options: options).value;
 
   FlagEvaluationDetails<double> getDoubleDetails(
     String flagKey,
@@ -1091,7 +1096,8 @@ final class OpenFeatureClient {
     String flagKey,
     Map<String, Object?> defaultValue, {
     EvaluationOptions? options,
-  }) => getStructureDetails(flagKey, defaultValue, options: options).value;
+  }) =>
+      getStructureDetails(flagKey, defaultValue, options: options).value;
 
   FlagEvaluationDetails<Map<String, Object?>> getStructureDetails(
     String flagKey,
@@ -1131,8 +1137,7 @@ final class OpenFeatureClient {
     ResolutionDetails<T> Function(
       FeatureProvider provider,
       EvaluationContext context,
-    )
-    resolve, {
+    ) resolve, {
     EvaluationOptions? options,
   }) {
     final provider = _api._providerForDomain(metadata.domain);
@@ -1141,7 +1146,7 @@ final class OpenFeatureClient {
     final hooks = <Hook>[..._api._hooks, ..._hooks, ...?options?.hooks];
     ProviderMetadata providerMetadata =
         _api._providerRecords[provider]?.metadata ??
-        const ProviderMetadata(name: 'unknown');
+            const ProviderMetadata(name: 'unknown');
     Object? setupError;
     try {
       providerMetadata = provider.metadata;
@@ -1228,9 +1233,8 @@ final class OpenFeatureClient {
     return FlagEvaluationDetails<T>(
       flagKey: flagKey,
       value: defaultValue,
-      errorCode: error is OpenFeatureException
-          ? error.errorCode
-          : ErrorCode.general,
+      errorCode:
+          error is OpenFeatureException ? error.errorCode : ErrorCode.general,
       errorMessage: error.toString(),
       reason: 'ERROR',
     );

--- a/packages/openfeature_dart_client_sdk/lib/src/events.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/events.dart
@@ -20,8 +20,8 @@ final class ProviderEvent {
     this.message,
     this.errorCode,
     Map<String, Object> metadata = const {},
-  }) : flagsChanged = List<String>.unmodifiable(flagsChanged),
-       metadata = immutableMetadata(metadata, path: 'eventMetadata');
+  })  : flagsChanged = List<String>.unmodifiable(flagsChanged),
+        metadata = immutableMetadata(metadata, path: 'eventMetadata');
 
   final ProviderEventType type;
   final List<String> flagsChanged;
@@ -40,8 +40,8 @@ final class ProviderEventDetails {
     this.message,
     this.errorCode,
     Map<String, Object> metadata = const {},
-  }) : flagsChanged = List<String>.unmodifiable(flagsChanged),
-       metadata = immutableMetadata(metadata, path: 'eventMetadata');
+  })  : flagsChanged = List<String>.unmodifiable(flagsChanged),
+        metadata = immutableMetadata(metadata, path: 'eventMetadata');
 
   final ProviderEventType type;
   final ProviderMetadata providerMetadata;

--- a/packages/openfeature_dart_client_sdk/lib/src/hooks.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/hooks.dart
@@ -9,7 +9,7 @@ enum FlagValueType { boolean, string, integer, double, structure }
 /// Immutable hook hints supplied with one flag evaluation.
 final class HookHints {
   HookHints([Map<String, Object?> values = const {}])
-    : values = immutableStructure(values, path: 'hookHints');
+      : values = immutableStructure(values, path: 'hookHints');
 
   final Map<String, Object?> values;
 
@@ -87,8 +87,8 @@ final class EvaluationOptions {
   EvaluationOptions({
     Iterable<Hook> hooks = const [],
     Map<String, Object?> hookHints = const {},
-  }) : hooks = List<Hook>.unmodifiable(hooks),
-       hookHints = HookHints(hookHints);
+  })  : hooks = List<Hook>.unmodifiable(hooks),
+        hookHints = HookHints(hookHints);
 
   final List<Hook> hooks;
   final HookHints hookHints;

--- a/packages/openfeature_dart_client_sdk/lib/src/in_memory_provider.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/in_memory_provider.dart
@@ -11,7 +11,7 @@ import 'provider.dart';
 /// A provider for conformance tests and application tests.
 final class InMemoryProvider implements FeatureProvider, ProviderEventSource {
   InMemoryProvider([Map<String, Object> flags = const {}])
-    : _flags = _copyFlags(flags);
+      : _flags = _copyFlags(flags);
 
   Map<String, Object> _flags;
   final StreamController<ProviderEvent> _events =
@@ -44,35 +44,40 @@ final class InMemoryProvider implements FeatureProvider, ProviderEventSource {
     String flagKey,
     bool defaultValue,
     EvaluationContext context,
-  ) => _resolve(flagKey, defaultValue);
+  ) =>
+      _resolve(flagKey, defaultValue);
 
   @override
   ResolutionDetails<double> resolveDoubleValue(
     String flagKey,
     double defaultValue,
     EvaluationContext context,
-  ) => _resolve(flagKey, defaultValue);
+  ) =>
+      _resolve(flagKey, defaultValue);
 
   @override
   ResolutionDetails<int> resolveIntegerValue(
     String flagKey,
     int defaultValue,
     EvaluationContext context,
-  ) => _resolve(flagKey, defaultValue);
+  ) =>
+      _resolve(flagKey, defaultValue);
 
   @override
   ResolutionDetails<String> resolveStringValue(
     String flagKey,
     String defaultValue,
     EvaluationContext context,
-  ) => _resolve(flagKey, defaultValue);
+  ) =>
+      _resolve(flagKey, defaultValue);
 
   @override
   ResolutionDetails<Map<String, Object?>> resolveStructureValue(
     String flagKey,
     Map<String, Object?> defaultValue,
     EvaluationContext context,
-  ) => _resolve(flagKey, immutableStructure(defaultValue));
+  ) =>
+      _resolve(flagKey, immutableStructure(defaultValue));
 
   ResolutionDetails<T> _resolve<T>(String flagKey, T defaultValue) {
     if (!_flags.containsKey(flagKey)) {

--- a/packages/openfeature_dart_client_sdk/lib/src/no_op_provider.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/no_op_provider.dart
@@ -16,35 +16,40 @@ final class NoOpProvider implements FeatureProvider {
     String flagKey,
     bool defaultValue,
     EvaluationContext context,
-  ) => _details(defaultValue);
+  ) =>
+      _details(defaultValue);
 
   @override
   ResolutionDetails<double> resolveDoubleValue(
     String flagKey,
     double defaultValue,
     EvaluationContext context,
-  ) => _details(defaultValue);
+  ) =>
+      _details(defaultValue);
 
   @override
   ResolutionDetails<int> resolveIntegerValue(
     String flagKey,
     int defaultValue,
     EvaluationContext context,
-  ) => _details(defaultValue);
+  ) =>
+      _details(defaultValue);
 
   @override
   ResolutionDetails<String> resolveStringValue(
     String flagKey,
     String defaultValue,
     EvaluationContext context,
-  ) => _details(defaultValue);
+  ) =>
+      _details(defaultValue);
 
   @override
   ResolutionDetails<Map<String, Object?>> resolveStructureValue(
     String flagKey,
     Map<String, Object?> defaultValue,
     EvaluationContext context,
-  ) => _details(defaultValue);
+  ) =>
+      _details(defaultValue);
 
   ResolutionDetails<T> _details<T>(T defaultValue) {
     return ResolutionDetails<T>(

--- a/packages/openfeature_dart_client_sdk/lib/src/provider.dart
+++ b/packages/openfeature_dart_client_sdk/lib/src/provider.dart
@@ -86,7 +86,7 @@ abstract interface class TrackingProvider {
 /// Data associated with one tracking call.
 final class TrackingEventDetails {
   TrackingEventDetails({this.value, Map<String, Object?> attributes = const {}})
-    : attributes = immutableStructure(attributes, path: 'trackingAttributes');
+      : attributes = immutableStructure(attributes, path: 'trackingAttributes');
 
   final num? value;
   final Map<String, Object?> attributes;

--- a/packages/openfeature_dart_client_sdk/pubspec.yaml
+++ b/packages/openfeature_dart_client_sdk/pubspec.yaml
@@ -6,15 +6,15 @@ repository: https://github.com/open-feature/dart-server-sdk
 issue_tracker: https://github.com/open-feature/dart-server-sdk/issues
 
 environment:
-  sdk: ^3.12.2
+  sdk: '>=3.6.0 <4.0.0'
 
 dev_dependencies:
-  # Keep minimum-dependency tests on analyzer dependencies compatible with Dart 3.12.
-  analyzer: ^8.1.1
+  # Keep the lower bounds compatible with the package's minimum Dart SDK.
+  analyzer: '>=7.5.4 <9.0.0'
   coverage: ^1.15.0
-  # Dart 3.12 requires the SDK-layout-aware frontend server client.
+  # Dart 3 requires the SDK-layout-aware frontend server client.
   frontend_server_client: ^4.0.0
-  lints: ^6.0.0
+  lints: '>=5.0.0 <7.0.0'
   # Keep the Chrome test runner on the two-argument connection callback API.
   shelf_web_socket: ^2.0.1
   test: ^1.26.3

--- a/packages/openfeature_dart_client_sdk/test/client_sdk_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/client_sdk_test.dart
@@ -198,15 +198,15 @@ void main() {
         await event,
         isA<ProviderEvent>()
             .having(
-              (value) => value.type,
-              'type',
-              ProviderEventType.configurationChanged,
-            )
+          (value) => value.type,
+          'type',
+          ProviderEventType.configurationChanged,
+        )
             .having((value) => value.flagsChanged, 'flagsChanged', [
-              'new',
-              'old',
-              'same',
-            ]),
+          'new',
+          'old',
+          'same',
+        ]),
       );
     });
   });
@@ -605,9 +605,9 @@ class _CancelFailingShutdownProvider extends _TestProvider
 
   final StreamController<ProviderEvent> _events =
       StreamController<ProviderEvent>(
-        onCancel: () =>
-            Future<void>.error(StateError('event subscription cleanup failed')),
-      );
+    onCancel: () =>
+        Future<void>.error(StateError('event subscription cleanup failed')),
+  );
   int shutdownCalls = 0;
 
   @override
@@ -723,7 +723,7 @@ final class _RecordingHook extends HookAdapter {
 
 class _TestProvider implements FeatureProvider {
   _TestProvider(Map<String, Object> flags)
-    : _provider = InMemoryProvider(flags);
+      : _provider = InMemoryProvider(flags);
 
   final InMemoryProvider _provider;
 
@@ -735,33 +735,38 @@ class _TestProvider implements FeatureProvider {
     String flagKey,
     bool defaultValue,
     EvaluationContext context,
-  ) => _provider.resolveBooleanValue(flagKey, defaultValue, context);
+  ) =>
+      _provider.resolveBooleanValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<double> resolveDoubleValue(
     String flagKey,
     double defaultValue,
     EvaluationContext context,
-  ) => _provider.resolveDoubleValue(flagKey, defaultValue, context);
+  ) =>
+      _provider.resolveDoubleValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<int> resolveIntegerValue(
     String flagKey,
     int defaultValue,
     EvaluationContext context,
-  ) => _provider.resolveIntegerValue(flagKey, defaultValue, context);
+  ) =>
+      _provider.resolveIntegerValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<String> resolveStringValue(
     String flagKey,
     String defaultValue,
     EvaluationContext context,
-  ) => _provider.resolveStringValue(flagKey, defaultValue, context);
+  ) =>
+      _provider.resolveStringValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<Map<String, Object?>> resolveStructureValue(
     String flagKey,
     Map<String, Object?> defaultValue,
     EvaluationContext context,
-  ) => _provider.resolveStructureValue(flagKey, defaultValue, context);
+  ) =>
+      _provider.resolveStructureValue(flagKey, defaultValue, context);
 }

--- a/packages/openfeature_dart_client_sdk/test/coverage_contract_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/coverage_contract_test.dart
@@ -177,7 +177,7 @@ final class _ThrowingFinalHook extends HookAdapter {
 
 class _DelegatingProvider implements FeatureProvider {
   _DelegatingProvider([Map<String, Object> flags = const {'flag': true}])
-    : delegate = InMemoryProvider(flags);
+      : delegate = InMemoryProvider(flags);
 
   final InMemoryProvider delegate;
 
@@ -190,35 +190,40 @@ class _DelegatingProvider implements FeatureProvider {
     String flagKey,
     bool defaultValue,
     EvaluationContext context,
-  ) => delegate.resolveBooleanValue(flagKey, defaultValue, context);
+  ) =>
+      delegate.resolveBooleanValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<double> resolveDoubleValue(
     String flagKey,
     double defaultValue,
     EvaluationContext context,
-  ) => delegate.resolveDoubleValue(flagKey, defaultValue, context);
+  ) =>
+      delegate.resolveDoubleValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<int> resolveIntegerValue(
     String flagKey,
     int defaultValue,
     EvaluationContext context,
-  ) => delegate.resolveIntegerValue(flagKey, defaultValue, context);
+  ) =>
+      delegate.resolveIntegerValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<String> resolveStringValue(
     String flagKey,
     String defaultValue,
     EvaluationContext context,
-  ) => delegate.resolveStringValue(flagKey, defaultValue, context);
+  ) =>
+      delegate.resolveStringValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<Map<String, Object?>> resolveStructureValue(
     String flagKey,
     Map<String, Object?> defaultValue,
     EvaluationContext context,
-  ) => delegate.resolveStructureValue(flagKey, defaultValue, context);
+  ) =>
+      delegate.resolveStructureValue(flagKey, defaultValue, context);
 }
 
 final class _LifecycleProviderWithoutEvents extends _DelegatingProvider

--- a/packages/openfeature_dart_client_sdk/test/event_handlers_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/event_handlers_test.dart
@@ -47,9 +47,9 @@ void main() {
     final domainEvents = <ProviderEventDetails>[];
     api.addHandler(ProviderEventType.configurationChanged, apiEvents.add);
     api.getClient().addHandler(
-      ProviderEventType.configurationChanged,
-      defaultEvents.add,
-    );
+          ProviderEventType.configurationChanged,
+          defaultEvents.add,
+        );
     final fallbackClient = api.getClient('fallback');
     final fallbackSubscription = fallbackClient.addHandler(
       ProviderEventType.configurationChanged,
@@ -159,7 +159,7 @@ void main() {
 
 final class _EventProvider implements FeatureProvider, ProviderEventSource {
   _EventProvider({this.name = 'event-provider'})
-    : _delegate = InMemoryProvider({'flag': true});
+      : _delegate = InMemoryProvider({'flag': true});
 
   final String name;
   final InMemoryProvider _delegate;
@@ -195,33 +195,38 @@ final class _EventProvider implements FeatureProvider, ProviderEventSource {
     String flagKey,
     bool defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveBooleanValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveBooleanValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<double> resolveDoubleValue(
     String flagKey,
     double defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveDoubleValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveDoubleValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<int> resolveIntegerValue(
     String flagKey,
     int defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveIntegerValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveIntegerValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<String> resolveStringValue(
     String flagKey,
     String defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveStringValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveStringValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<Map<String, Object?>> resolveStructureValue(
     String flagKey,
     Map<String, Object?> defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveStructureValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveStructureValue(flagKey, defaultValue, context);
 }

--- a/packages/openfeature_dart_client_sdk/test/promotion_readiness_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/promotion_readiness_test.dart
@@ -297,35 +297,40 @@ class _DelegatingProvider implements FeatureProvider {
     String flagKey,
     bool defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveBooleanValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveBooleanValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<double> resolveDoubleValue(
     String flagKey,
     double defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveDoubleValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveDoubleValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<int> resolveIntegerValue(
     String flagKey,
     int defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveIntegerValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveIntegerValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<String> resolveStringValue(
     String flagKey,
     String defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveStringValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveStringValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<Map<String, Object?>> resolveStructureValue(
     String flagKey,
     Map<String, Object?> defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveStructureValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveStructureValue(flagKey, defaultValue, context);
 }
 
 class _SilentLifecycleProvider extends _DelegatingProvider

--- a/packages/openfeature_dart_client_sdk/test/race_safety_test.dart
+++ b/packages/openfeature_dart_client_sdk/test/race_safety_test.dart
@@ -250,7 +250,7 @@ final class _GatedContextProvider
         ProviderEventSource,
         ShutdownProvider {
   _GatedContextProvider({this.name = 'gated-provider'})
-    : _delegate = InMemoryProvider({'flag': true});
+      : _delegate = InMemoryProvider({'flag': true});
 
   final String name;
   final InMemoryProvider _delegate;
@@ -319,26 +319,30 @@ final class _GatedContextProvider
     String flagKey,
     double defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveDoubleValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveDoubleValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<int> resolveIntegerValue(
     String flagKey,
     int defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveIntegerValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveIntegerValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<String> resolveStringValue(
     String flagKey,
     String defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveStringValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveStringValue(flagKey, defaultValue, context);
 
   @override
   ResolutionDetails<Map<String, Object?>> resolveStructureValue(
     String flagKey,
     Map<String, Object?> defaultValue,
     EvaluationContext context,
-  ) => _delegate.resolveStructureValue(flagKey, defaultValue, context);
+  ) =>
+      _delegate.resolveStructureValue(flagKey, defaultValue, context);
 }


### PR DESCRIPTION
## Motivation

The client beta requires Dart 3.12.2. This prevents use by Flutter SDKs that support Dart 3.6.

## Changes and Decisions

- Lower only the client package constraint to Dart 3.6. The server package remains on Dart 3.12.2.
- Keep client development dependencies compatible with Dart 3.6.
- Replace repeated wildcard parameters that require Dart 3.7.
- Test each package against its own minimum SDK, current stable, beta, and minimum dependencies.
- Treat Dart 3.6 as the client compatibility floor, not a Dart LTS release.